### PR TITLE
Implementing checks for start/stop/restart and adding reload - Adding tune.sh and Postgresql.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please read [Installing Lisk (from Binaries)](https://github.com/LiskHQ/lisk-doc
 - [Darwin (native)](#darwin)
 - [FreeBSD (native)](#freebsd)
 
-**NOTE:** For each platform, the resulting packages are placed within the `src` directory, using the following naming convention: `lisk-{version}-{os}-{architecture}.zip`.
+**NOTE:** For each platform, the resulting packages are placed within the `src` directory, using the following naming convention: `lisk-{version}-{os}-{architecture}.tar.gz`.
 
 ## Linux
 

--- a/scripts/installLisk.sh
+++ b/scripts/installLisk.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+####################################################
+#Lisk Installation Script
+# by Isabella D.
+#
+#
+#
+#
+####################################################
+
+#Variable Declaration
+UNAME=$(uname)-$(uname -m)
+defaultLiskLocation=~
+
+#Verification Checks
+if [ "$USER" == "root" ]; then
+  echo "Error: Lisk should not be installed be as root. Exiting."
+  exit 1
+fi
+
+user_prompts() {
+read -r -p "Where do you want to install Lisk to? (Default $defaultLiskLocation):  " liskLocation
+liskLocation=${liskLocation:-$defaultLiskLocation}
+if [[ ! -r "$liskLocation" ]]
+then
+echo "$liskLocation is not valid, please check and re-excute"
+exit 2;
+fi
+}
+
+install_prereqs() {
+if [[ -f "/etc/redhat-release" ]]; then
+	sudo yum -yq install curl tar 
+fi
+
+if [[ -f "/etc/debian_version" ]]; then
+	sudo apt-get update
+	sudo apt-get install -yyq curl tar 
+fi
+if [[ "$(uname)" == "FreeBSD" ]]; then
+	sudo pkg install curl tar 
+fi
+
+}
+  
+ntp_checks() {
+#Install NTP or Chrony for Time Management - Physical Machines only
+if [[ "$(uname)" == "Linux" ]]; then
+ if [[ -f "/etc/debian_version" &&  ! -f "/proc/user_beancounters" ]]; then
+   if pgrep -x "ntpd" > /dev/null
+    then
+      echo "√ NTP is running"
+    else
+      echo "X NTP is not running"
+      read -r -n 1 -p "Would like to install NTP? (y/n): " $REPLY
+	  if [[  $REPLY =~ ^[Yy]$ ]]
+		then
+		echo -e "\nInstalling NTP, please provide sudo password.\n"
+        sudo apt-get install ntp -yyq
+        sudo service ntp stop
+        sudo ntpdate pool.ntp.org
+        sudo service ntp start
+			if pgrep -x "ntpd" > /dev/null
+				then
+					echo "√ NTP is running"
+				else
+					echo -e "\nLisk requires NTP running on Debian based systems. Please check /etc/ntp.conf and correct any issues."
+					exit 0
+			fi
+		else
+		echo -e "\nLisk requires NTP on Debian based systems, exiting."
+		exit 0
+	  fi
+   fi #End Debian Checks
+   
+ elif [[ -f "/etc/redhat-release" &&  ! -f "/proc/user_beancounters" ]]; then
+   if pgrep -x "ntpd" > /dev/null
+   then
+      echo "√ NTP is running"
+   else
+      if pgrep -x "chronyd" > /dev/null
+      then
+        echo "√ Chrony is running"
+      else
+        echo "X NTP and Chrony are not running"
+        read -r -n 1 -p "Would like to install NTP? (y/n): " $REPLY
+        if [[  $REPLY =~ ^[Yy]$ ]]
+        then
+        	echo -e "\nInstalling NTP, please provide sudo password.\n"
+      		sudo yum -yq install ntp ntpdate ntp-doc
+		sudo chkconfig ntpd on
+		sudo service ntpd stop
+		sudo ntpdate pool.ntp.org
+		sudo service ntpd start
+		if pgrep -x "ntpd" > /dev/null
+			then
+				echo "√ NTP is running"
+			else
+				echo -e "\nLisk requires NTP running on Debian based systems. Please check /etc/ntp.conf and correct any issues."
+				exit 0
+		fi
+      else
+      echo -e "\nLisk requires NTP or Chrony on RHEL based systems, exiting."
+      exit 0
+        fi
+      fi
+   fi #End Redhat Checks
+   
+ elif [[ -f "/proc/user_beancounters" ]]; then
+   echo "_ Running OpenVZ VM, NTP and Chrony are not required"
+ fi
+elif [[ "$(uname)" == "FreeBSD" ]]; then
+	if pgrep -x "ntpd" > /dev/null
+	   then
+		  echo "√ NTP is running"
+	   else
+		  echo "X NTP is not running"
+		  read -r -n 1 -p "Would like to install NTP? (y/n): " $REPLY
+		  if [[  $REPLY =~ ^[Yy]$ ]]
+		  then
+		  echo -e "\nInstalling NTP, please provide sudo password.\n"
+		  sudo pkg install ntp
+		  sudo sh -c "echo 'ntpd_enable=\"YES\"' >> /etc/rc.conf"
+		  sudo ntpdate -u pool.ntp.org
+		  sudo service ntpd start
+			if pgrep -x "ntpd" > /dev/null
+				then
+					echo "√ NTP is running"
+				else
+					echo -e "\nLisk requires NTP running on FreeBSD based systems. Please check /etc/ntp.conf and correct any issues."
+					exit 0
+			fi
+		  else
+		  echo -e "\nLisk requires NTP FreeBSD based systems, exiting."
+		  exit 0
+	    fi
+    fi #End FreeBSD Checks
+elif [[ "$(uname)" == "Darwin" ]]; then
+	if pgrep -x "ntpd" > /dev/null
+	   then
+		    echo "√ NTP is running"
+	   else
+			sudo launchctl load /System/Library/LaunchDaemons/org.ntp.ntpd.plist
+			sleep 1
+			if pgrep -x "ntpd" > /dev/null
+				then
+					echo "√ NTP is running"
+				else
+				echo -e "\nNTP did not start, Please verify its configured on your system"
+				exit 0
+			fi
+	fi	#End Darwin Checks
+fi #End NTP Checks
+}
+
+install_lisk() {
+	
+liskVersion=`curl -s https://downloads.lisk.io/lisk/test/ | grep $UNAME | cut -d'"' -f2`
+liskDir=`echo $liskVersion | cut -d'.' -f1`
+
+echo -e "\nDownloading current Lisk binaries: "$liskVersion
+
+curl -s https://downloads.lisk.io/lisk/test/$liskVersion -o $liskVersion
+
+#Disabled until file is present
+#curl -s https://downloads.lisk.iso/lisk/test/lisk_checksum.md5 -o lisk_checksum.md5
+
+#md5=`md5sum $liskVersion | awk '{print $1}'`
+#md5_compare=`grep "$liskVersion" lisk_checksum.md5 | awk '{print $1}'`
+
+#if [[ "$md5" == "$md5_compare" ]]; then
+#echo "Checksum Passed!"
+#else
+#echo "Checksum Failed, aborting installation"
+#rm -f $liskVersion lisk_checksum.md5
+#exit 0
+#fi
+
+echo -e "Extracting Lisk binaries to "$liskLocation/lisk
+
+tar -xzf $liskVersion -C $liskLocation 
+
+mv $liskDir $liskLocation/lisk
+
+echo -e "\nCleaning up downloaded files"
+rm -f $liskVersion lisk_checksum.md5
+
+cd $liskLocation/lisk
+
+echo -e "\nColdstarting Lisk for the first time"
+bash lisk.sh coldstart
+
+echo -e "\nStopping Lisk to perform database tuning"
+bash lisk.sh stop
+
+
+rm -f $liskLocation/lisk/pgsql/data/postgresql.conf
+cp ./postgresql.conf $liskLocation/lisk/pgsql/data/postgresql.conf
+
+echo -e "\nExecuting database tuning operation"
+bash $liskLocation/lisk/tune.sh
+
+echo -e "\nStarting Lisk with all parameters in place."
+bash lisk.sh start
+
+sleep 5
+blockHeight=`curl -s http://localhost:7000/api/loader/status/sync | cut -d: -f5 | cut -d} -f1`
+
+echo -e "\nCurrent Block Height: " $blockHeight
+}
+
+upgrade_lisk() {
+	echo "Not supported yet"
+}
+
+case $1 in
+"install")
+  user_prompts
+  ntp_checks
+  install_prereqs
+  install_lisk
+  ;;
+  "upgrade")
+  upgrade_lisk
+  ;;
+*)
+  echo "Error: Unrecognized command."
+  echo ""
+  echo "Available commands are: install upgrade"
+  ;;
+esac
+
+

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -137,7 +137,7 @@ coldstart_lisk() {
 start_postgresql() {
   if pgrep -x "postgres" &> /dev/null; then
         echo "√ Postgresql is running"
-  else
+  fi
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
   sleep 1
   if [ $? != 0 ]; then
@@ -146,13 +146,12 @@ start_postgresql() {
   else
     echo "√ Postgresql started successfully."
   fi
-  fi
 }
 
 stop_postgresql() {
   if ! pgrep -x "postgres" &> /dev/null; then
         echo "√ Postgresql is not running"
-  else
+  fi
   while pgrep -x "postgres" &> /dev/null; do
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE stop &> /dev/null
   if [ $? == 0 ]; then
@@ -161,7 +160,6 @@ stop_postgresql() {
   echo "X Postgresql failed to stop"
   fi
   done
-  fi
 }
 
 

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -136,7 +136,7 @@ coldstart_lisk() {
 
 start_postgresql() {
   if pgrep -x "postgres" &> /dev/null; then
-        echo "√ Postgres is already running"
+        echo "√ Postgres is running"
   else
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
   sleep 1
@@ -164,7 +164,7 @@ stop_postgresql() {
 
 start_lisk() {
   if pgrep -x "node" &> /dev/null; then
-        echo "√ Lisk is already running"
+        echo "√ Lisk is running"
   exit 1
   fi
   forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js &> /dev/null

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -143,8 +143,17 @@ start_postgresql() {
 }
 
 stop_postgresql() {
+  while pgrep -x "postgres" &> /dev/null; do
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE stop &> /dev/null
+  if [ $? == 0 ]; then
+  echo "\xe2\x88\x9a Postgres stopped successfully"
+  break
+  else
+  echo "X Postgres failed to stop"
+  fi
+  done
 }
+
 
 start_lisk() {
   forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js &> /dev/null
@@ -156,13 +165,20 @@ start_lisk() {
 }
 
 stop_lisk() {
+  if ! pgrep -x "node" &> /dev/null; then
+        echo "Lisk is not running"
+  fi
+  while pgrep -x "node" &> /dev/null; do
   forever stop lisk &> /dev/null
   if [ $? !=  0 ]; then
     echo "X Failed to stop lisk."
   else
-    echo "√ Lisk stopped successfully."
+    echo "\xe2\x88\x9a Lisk stopped successfully."
+  break
   fi
+ done
 }
+
 
 rebuild_lisk() {
   create_database

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -169,7 +169,6 @@ start_lisk() {
   if pgrep -x "node" &> /dev/null; then
         echo "√ Lisk is running"
   exit 1
-  fi
   else
   forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js &> /dev/null
   if [ $? == 0 ]; then

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -135,10 +135,16 @@ coldstart_lisk() {
 }
 
 start_postgresql() {
+  if pgrep -x "postgres" &> /dev/null; then
+        echo "√ Postgres is already running"
+  else
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
   if [ $? != 0 ]; then
     echo "X Failed to start postgresql."
     exit 1
+  else
+    echo "√ Postgres started successfully."
+  fi
   fi
 }
 
@@ -146,7 +152,7 @@ stop_postgresql() {
   while pgrep -x "postgres" &> /dev/null; do
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE stop &> /dev/null
   if [ $? == 0 ]; then
-  echo "\xe2\x88\x9a Postgres stopped successfully"
+  echo "√ Postgres stopped successfully"
   break
   else
   echo "X Postgres failed to stop"
@@ -156,6 +162,10 @@ stop_postgresql() {
 
 
 start_lisk() {
+  if pgrep -x "node" &> /dev/null; then
+        echo "√ Lisk is already running"
+  exit 1
+  fi
   forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js &> /dev/null
   if [ $? == 0 ]; then
     echo "√ Lisk started successfully."
@@ -166,14 +176,14 @@ start_lisk() {
 
 stop_lisk() {
   if ! pgrep -x "node" &> /dev/null; then
-        echo "Lisk is not running"
+        echo "√ Lisk is not running"
   fi
   while pgrep -x "node" &> /dev/null; do
   forever stop lisk &> /dev/null
   if [ $? !=  0 ]; then
     echo "X Failed to stop lisk."
   else
-    echo "\xe2\x88\x9a Lisk stopped successfully."
+    echo "√ Lisk stopped successfully."
   break
   fi
  done

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -36,10 +36,10 @@ create_user() {
   createuser --createdb "$DB_USER" &> /dev/null
   psql -qd postgres -c "ALTER USER "$DB_USER" WITH PASSWORD '$DB_PASS';" &> /dev/null
   if [ $? != 0 ]; then
-    echo "X Failed to create postgres user."
+    echo "X Failed to create Postgresql user."
     exit 1
   else
-    echo "√ Postgres user created successfully."
+    echo "√ Postgresql user created successfully."
   fi
 }
 
@@ -47,10 +47,10 @@ create_database() {
   dropdb --if-exists "$DB_NAME" &> /dev/null
   createdb "$DB_NAME" &> /dev/null
   if [ $? != 0 ]; then
-    echo "X Failed to create postgres database."
+    echo "X Failed to create Postgresql database."
     exit 1
   else
-    echo "√ Postgres database created successfully."
+    echo "√ Postgresql database created successfully."
   fi
 }
 
@@ -136,29 +136,32 @@ coldstart_lisk() {
 
 start_postgresql() {
   if pgrep -x "postgres" &> /dev/null; then
-        echo "√ Postgres is running"
+        echo "√ Postgresql is running"
   else
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
   sleep 1
   if [ $? != 0 ]; then
-    echo "X Failed to start postgresql."
+    echo "X Failed to start Postgresql."
     exit 1
   else
-    echo "√ Postgres started successfully."
+    echo "√ Postgresql started successfully."
   fi
   fi
 }
 
 stop_postgresql() {
+  if ! pgrep -x "postgres" &> /dev/null; then
+        echo "√ Postgresql is not running"
+  else
   while pgrep -x "postgres" &> /dev/null; do
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE stop &> /dev/null
   if [ $? == 0 ]; then
-  echo "√ Postgres stopped successfully"
-  break
+  echo "√ Postgresql stopped successfully"
   else
-  echo "X Postgres failed to stop"
+  echo "X Postgresql failed to stop"
   fi
   done
+  fi
 }
 
 

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -232,8 +232,15 @@ case $1 in
   stop_lisk
   stop_postgresql
   ;;
+  "reload")
+  stop_lisk
+  start_lisk
+  ;;
 "restart")
   stop_lisk
+  stop_postgresql
+  start_postgresql
+  sleep 1
   start_lisk
   ;;
 "rebuild")

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -232,7 +232,7 @@ case $1 in
   stop_lisk
   stop_postgresql
   ;;
-  "reload")
+"reload")
   stop_lisk
   start_lisk
   ;;
@@ -260,6 +260,6 @@ case $1 in
 *)
   echo "Error: Unrecognized command."
   echo ""
-  echo "Available commands are: coldstart start stop restart rebuild status logs"
+  echo "Available commands are: coldstart start stop reload restart rebuild status logs "
   ;;
 esac

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -139,6 +139,7 @@ start_postgresql() {
         echo "√ Postgres is already running"
   else
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
+  sleep 1
   if [ $? != 0 ]; then
     echo "X Failed to start postgresql."
     exit 1
@@ -225,7 +226,7 @@ case $1 in
   ;;
 "start")
   start_postgresql
-  sleep 1
+  sleep 2
   start_lisk
   ;;
 "stop")

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -137,7 +137,7 @@ coldstart_lisk() {
 start_postgresql() {
   if pgrep -x "postgres" &> /dev/null; then
         echo "√ Postgresql is running"
-  fi
+  else
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE start &> /dev/null
   sleep 1
   if [ $? != 0 ]; then
@@ -146,12 +146,13 @@ start_postgresql() {
   else
     echo "√ Postgresql started successfully."
   fi
+  fi
 }
 
 stop_postgresql() {
   if ! pgrep -x "postgres" &> /dev/null; then
         echo "√ Postgresql is not running"
-  fi
+  else 
   while pgrep -x "postgres" &> /dev/null; do
   pg_ctl -D $DB_DATA -l $DB_LOG_FILE stop &> /dev/null
   if [ $? == 0 ]; then
@@ -160,6 +161,7 @@ stop_postgresql() {
   echo "X Postgresql failed to stop"
   fi
   done
+  fi
 }
 
 
@@ -168,18 +170,20 @@ start_lisk() {
         echo "√ Lisk is running"
   exit 1
   fi
+  else
   forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js &> /dev/null
   if [ $? == 0 ]; then
     echo "√ Lisk started successfully."
   else
     echo "X Failed to start lisk."
   fi
+  fi
 }
 
 stop_lisk() {
   if ! pgrep -x "node" &> /dev/null; then
         echo "√ Lisk is not running"
-  fi
+  else
   while pgrep -x "node" &> /dev/null; do
   forever stop lisk &> /dev/null
   if [ $? !=  0 ]; then
@@ -188,6 +192,7 @@ stop_lisk() {
     echo "√ Lisk stopped successfully."
   fi
  done
+ fi
 }
 
 

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -185,7 +185,6 @@ stop_lisk() {
     echo "X Failed to stop lisk."
   else
     echo "√ Lisk stopped successfully."
-  break
   fi
  done
 }

--- a/scripts/postgres.conf
+++ b/scripts/postgres.conf
@@ -1,0 +1,631 @@
+
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'           # use data in another directory
+                                        # (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'     # host-based authentication file
+                                        # (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf' # ident configuration file
+                                        # (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''                 # write an extra PID file
+                                        # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+#listen_addresses = 'localhost'         # what IP address(es) to listen on;
+                                        # comma-separated list of addresses;
+                                        # defaults to 'localhost'; use '*' for all
+                                        # (change requires restart)
+#port = 5432                            # (change requires restart)
+max_connections = mc                 # (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3     # (change requires restart)
+#unix_socket_directories = '/tmp'       # comma-separated list of directories
+                                        # (change requires restart)
+#unix_socket_group = ''                 # (change requires restart)
+#unix_socket_permissions = 0777         # begin with 0 to use octal notation
+                                        # (change requires restart)
+#bonjour = off                          # advertise server via Bonjour
+                                        # (change requires restart)
+#bonjour_name = ''                      # defaults to the computer name
+                                        # (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min          # 1s-600s
+#ssl = off                              # (change requires restart)
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+                                        # (change requires restart)
+#ssl_prefer_server_ciphers = on         # (change requires restart)
+#ssl_ecdh_curve = 'prime256v1'          # (change requires restart)
+#ssl_cert_file = 'server.crt'           # (change requires restart)
+#ssl_key_file = 'server.key'            # (change requires restart)
+#ssl_ca_file = ''                       # (change requires restart)
+#ssl_crl_file = ''                      # (change requires restart)
+#password_encryption = on
+#db_user_namespace = off
+#row_security = on
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = ''
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0                # TCP_KEEPIDLE, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_interval = 0            # TCP_KEEPINTVL, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_count = 0               # TCP_KEEPCNT;
+                                        # 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = sb              # min 128kB
+                                        # (change requires restart)
+#huge_pages = try                       # on, off, or try
+                     # (change requires restart)
+#temp_buffers = 8MB                     # min 800kB
+#max_prepared_transactions = 0          # zero disables the feature
+                                        # (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = wmem                     # min 64kB
+maintenance_work_mem = mwm            # min 1MB
+#autovacuum_work_mem = -1               # min 1MB, or -1 to use maintenance_work_mem
+#max_stack_depth = 2MB                  # min 100kB
+dynamic_shared_memory_type = posix      # the default is the first option
+                                        # supported by the operating system:
+                                        #   posix
+                                        #   sysv
+                                        #   windows
+                                        #   mmap
+                                        # use none to disable dynamic shared memory
+
+# - Disk -
+
+#temp_file_limit = -1                   # limits per-session temp file space
+                                        # in kB, or -1 for no limit
+
+# - Kernel Resource Usage -
+
+#max_files_per_process = 1000           # min 25
+                                        # (change requires restart)
+#shared_preload_libraries = ''          # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0                  # 0-100 milliseconds
+#vacuum_cost_page_hit = 1               # 0-10000 credits
+#vacuum_cost_page_miss = 10             # 0-10000 credits
+#vacuum_cost_page_dirty = 20            # 0-10000 credits
+#vacuum_cost_limit = 200                # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms                 # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100            # 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0          # 0-10.0 multipler on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1           # 1-1000; 0 disables prefetching
+#max_worker_processes = 8
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = archive                     # minimal, archive, hot_standby, or logical
+                                        # (change requires restart)
+#fsync = on                             # turns forced synchronization on or off
+#synchronous_commit = on                # synchronization level;
+                                        # off, local, remote_write, or on
+#wal_sync_method = fsync                # the default is the first option
+                                        # supported by the operating system:
+                                        #   open_datasync
+                                        #   fdatasync (default on Linux)
+                                        #   fsync
+                                        #   fsync_writethrough
+                                        #   open_sync
+#full_page_writes = on                  # recover from partial page writes
+#wal_compression = off                  # enable compression of full-page writes
+#wal_log_hints = off                    # also do full page writes of non-critical updates
+                                        # (change requires restart)
+wal_buffers = wb                      # min 32kB, -1 sets based on shared_buffers
+                                        # (change requires restart)
+#wal_writer_delay = 200ms               # 1-10000 milliseconds
+
+#commit_delay = 0                       # range 0-100000, in microseconds
+#commit_siblings = 5                    # range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min              # range 30s-1h
+max_wal_size = maxws
+min_wal_size = minws
+checkpoint_completion_target = cct     # checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s               # 0 disables
+
+# - Archiving -
+
+#archive_mode = on       # enables archiving; off, on, or always
+                                # (change requires restart)
+#archive_command =                # command to use to archive a logfile segment
+                                # placeholders: %p = path of file to archive
+                                #               %f = file name only
+                                # e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 300           # force a logfile segment switch after this
+                                # number of seconds; 0 disables
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0            # max number of walsender processes
+                                # (change requires restart)
+#wal_keep_segments = 0          # in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s       # in milliseconds; 0 disables
+
+#max_replication_slots = 0      # max number of replication slots
+                                # (change requires restart)
+#track_commit_timestamp = off   # collect timestamp of transaction commit
+                                # (change requires restart)
+
+# - Master Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = '' # standby servers that provide sync rep
+                                # comma-separated list of application_name
+                                # from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0   # number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a master server.
+
+#hot_standby = off                      # "on" allows queries during recovery
+                                        # (change requires restart)
+#max_standby_archive_delay = 30s        # max delay before canceling queries
+                                        # when reading WAL from archive;
+                                        # -1 allows indefinite delay
+#max_standby_streaming_delay = 30s      # max delay before canceling queries
+                                        # when reading streaming WAL;
+                                        # -1 allows indefinite delay
+#wal_receiver_status_interval = 10s     # send replies at least this often
+                                        # 0 disables
+#hot_standby_feedback = off             # send info from standby to prevent
+                                        # query conflicts
+#wal_receiver_timeout = 60s             # time that receiver waits for
+                                        # communication from master
+                                        # in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s       # time to wait before retrying to
+                                        # retrieve WAL after a failed attempt
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0                    # measured on an arbitrary scale
+#random_page_cost = 4.0                 # same scale as above
+#cpu_tuple_cost = 0.01                  # same scale as above
+#cpu_index_tuple_cost = 0.005           # same scale as above
+#cpu_operator_cost = 0.0025             # same scale as above
+effective_cache_size = ecs
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5                        # range 1-10
+#geqo_pool_size = 0                     # selects default based on effort
+#geqo_generations = 0                   # selects default based on effort
+#geqo_selection_bias = 2.0              # range 1.5-2.0
+#geqo_seed = 0.0                        # range 0.0-1.0
+
+# - Other Planner Options -
+
+default_statistics_target = dst        # range 1-10000
+#constraint_exclusion = partition       # on, off, or partition
+#cursor_tuple_fraction = 0.1            # range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8                # 1 disables collapsing of explicit
+                                        # JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'             # Valid values are combinations of
+                                        # stderr, csvlog, syslog, and eventlog,
+                                        # depending on platform.  csvlog
+                                        # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off                # Enable capturing of stderr and csvlog
+                                        # into log files. Required to be on for
+                                        # csvlogs.
+                                        # (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'pg_log'               # directory where log files are written,
+                                        # can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'        # log file name pattern,
+                                        # can include strftime() escapes
+#log_file_mode = 0600                   # creation mode for log files,
+                                        # begin with 0 to use octal notation
+#log_truncate_on_rotation = off         # If on, an existing log file with the
+                                        # same name as the new log file will be
+                                        # truncated rather than appended to.
+                                        # But such truncation only occurs on
+                                        # time-driven rotation, not on restarts
+                                        # or size-driven rotation.  Default is
+                                        # off, meaning append to existing files
+                                        # in all cases.
+#log_rotation_age = 1d                  # Automatic rotation of logfiles will
+                                        # happen after that time.  0 disables.
+#log_rotation_size = 10MB               # Automatic rotation of logfiles will
+                                        # happen after that much log output.
+                                        # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice           # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   log
+                                        #   notice
+                                        #   warning
+                                        #   error
+
+#log_min_messages = warning             # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic
+
+#log_min_error_statement = error        # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic (effectively off)
+
+#log_min_duration_statement = -1        # -1 is disabled, 0 logs all statements
+                                        # and their durations, > 0 logs only
+                                        # statements running at least this number
+                                        # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default          # terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = ''                   # special values:
+                                        #   %a = application name
+                                        #   %u = user name
+                                        #   %d = database name
+                                        #   %r = remote host and port
+                                        #   %h = remote host
+                                        #   %p = process ID
+                                        #   %t = timestamp without milliseconds
+                                        #   %m = timestamp with milliseconds
+                                        #   %i = command tag
+                                        #   %e = SQL state
+                                        #   %c = session ID
+                                        #   %l = session line number
+                                        #   %s = session start timestamp
+                                        #   %v = virtual transaction ID
+                                        #   %x = transaction ID (0 if none)
+                                        #   %q = stop here in non-session
+                                        #        processes
+                                        #   %% = '%'
+                                        # e.g. '<%u%%%d> '
+#log_lock_waits = off                   # log lock waits >= deadlock_timeout
+#log_statement = 'none'                 # none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1                    # log temporary files equal or larger
+                                        # than the specified size in kilobytes;
+                                        # -1 disables, 0 logs all temp files
+log_timezone = 'US/Central'
+
+
+# - Process Title -
+
+#cluster_name = ''                      # added to process titles if nonempty
+                                        # (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_io_timing = off
+#track_functions = none                 # none, pl, all
+#track_activity_query_size = 1024       # (change requires restart)
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on                        # Enable autovacuum subprocess?  'on'
+                                        # requires track_counts to also be on.
+#log_autovacuum_min_duration = -1       # -1 disables, 0 logs all actions and
+                                        # their durations, > 0 logs only
+                                        # actions running at least this number
+                                        # of milliseconds.
+#autovacuum_max_workers = 3             # max number of autovacuum subprocesses
+                                        # (change requires restart)
+#autovacuum_naptime = 1min              # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50       # min number of row updates before
+                                        # vacuum
+#autovacuum_analyze_threshold = 50      # min number of row updates before
+                                        # analyze
+#autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                                        # (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000        # maximum multixact age
+                                        # before forced vacuum
+                                        # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms    # default vacuum cost delay for
+                                        # autovacuum, in milliseconds;
+                                        # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1      # default vacuum cost limit for
+                                        # autovacuum, -1 means use
+                                        # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user", public'        # schema names
+#default_tablespace = ''                # a tablespace name, '' uses the default
+#temp_tablespaces = ''                  # a list of tablespace names, '' uses
+                                        # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0                  # in milliseconds, 0 is disabled
+#lock_timeout = 0                       # in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
+#bytea_output = 'hex'                   # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+#gin_pending_list_limit = 4MB
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'US/Central'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+                                        # abbreviations.  Currently, there are
+                                        #   Default
+                                        #   Australia (historical usage)
+                                        #   India
+                                        # You can create your own file in
+                                        # share/timezonesets/.
+#extra_float_digits = 0                 # min -15, max 3
+#client_encoding = sql_ascii            # actually, defaults to database
+                                        # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'                     # locale for system error message
+                                        # strings
+lc_monetary = 'en_US.UTF-8'                     # locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'                      # locale for number formatting
+lc_time = 'en_US.UTF-8'                         # locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64         # min 10
+                                        # (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+#max_pred_locks_per_transaction = 64    # min 10
+                                        # (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding        # on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#operator_precedence_warning = off
+#quote_all_identifiers = off
+#sql_inheritance = on
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off                    # terminate session on any error?
+#restart_after_crash = on               # reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'                 # include files ending in '.conf' from
+                                        # directory 'conf.d'
+#include_if_exists = 'exists.conf'      # include file only if it exists
+#include = 'special.conf'               # include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/scripts/postgresql.conf
+++ b/scripts/postgresql.conf
@@ -443,7 +443,7 @@ default_statistics_target = dst        # range 1-10000
 #log_temp_files = -1                    # log temporary files equal or larger
                                         # than the specified size in kilobytes;
                                         # -1 disables, 0 logs all temp files
-log_timezone = 'US/Central'
+log_timezone = 'UTC'
 
 
 # - Process Title -

--- a/scripts/tune.sh
+++ b/scripts/tune.sh
@@ -1,0 +1,155 @@
+
+#!/bin/bash
+#############################################################
+# Postgres Memory Tuning for Lisk                           #
+# by: Isabella D. 
+#
+#
+#
+#############################################################
+
+
+update_config() {
+
+if [[ "$(uname)" == "Linux" ]]; then
+cp ./pgsql/data/postgresql.conf ./pgsql/data/postgresql.conf.bak
+sed -i "s#mc#$max_connections#g" ./pgsql/data/postgresql.conf
+sed -i "s#sb#$shared_buffers#g" ./pgsql/data/postgresql.conf
+sed -i "s#ecs#$effective_cache_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#wmem#$work_mem#g" ./pgsql/data/postgresql.conf
+sed -i "s#mwm#$maintenance_work_mem#g" ./pgsql/data/postgresql.conf
+sed -i "s#minws#$min_wal_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#maxws#$max_wal_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#cct#$checkpoint_completion_target#g" ./pgsql/data/postgresql.conf
+sed -i "s#wb#$wal_buffers#g" ./pgsql/data/postgresql.conf
+sed -i "s#dst#$default_statistics_target#g" ./pgsql/data/postgresql.conf
+echo "Updates completed"
+fi
+if [[ "$(uname)" == "FreeBSD" ]]; then
+cp ./pgsql/data/postgresql.conf ./pgsql/data/postgresql.conf.bak
+sed -I .temp "s#mc#$max_connections#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#sb#$shared_buffers#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#ecs#$effective_cache_size#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#wmem#$work_mem#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#mwm#$maintenance_work_mem#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#minws#$min_wal_size#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#maxws#$max_wal_size#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#cct#$checkpoint_completion_target#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#wb#$wal_buffers#g" ./pgsql/data/postgresql.conf
+sed -I .temp "s#dst#$default_statistics_target#g" ./pgsql/data/postgresql.conf
+fi
+
+#### UNTESTED 
+if [[ "$(uname)" == "Darwin" ]]; then
+cp ./pgsql/data/postgresql.conf ./pgsql/data/postgresql.conf.bak
+sed -i "s#mc#$max_connections#g" ./pgsql/data/postgresql.conf
+sed -i "s#sb#$shared_buffers#g" ./pgsql/data/postgresql.conf
+sed -i "s#ecs#$effective_cache_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#wmem#$work_mem#g" ./pgsql/data/postgresql.conf
+sed -i "s#mwm#$maintenance_work_mem#g" ./pgsql/data/postgresql.conf
+sed -i "s#minws#$min_wal_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#maxws#$max_wal_size#g" ./pgsql/data/postgresql.conf
+sed -i "s#cct#$checkpoint_completion_target#g" ./pgsql/data/postgresql.conf
+sed -i "s#wb#$wal_buffers#g" ./pgsql/data/postgresql.conf
+sed -i "s#dst#$default_statistics_target#g" ./pgsql/data/postgresql.conf
+fi
+
+}
+
+
+if [[ -f "./pgsql/data/postgresql.conf.bak" ]]; then
+cp -f ./pgsql/data/postgresql.conf.bak ./pgsql/data/postgresql.conf
+fi
+
+
+if [[ "$(uname)" == "Linux" ]]; then
+memoryBase=`cat /proc/meminfo | grep MemTotal | awk '{print $2 / 1024 /4}' | cut -f1 -d"."`
+echo $memoryBase
+fi
+
+if [[ "$(uname)" == "FreeBSD" ]]; then
+memoryBase=`sysctl hw.physmem | awk '{print $2 / 1024 / 1024/ 4}' |cut -f1 -d"."`
+echo $memoryBase
+fi
+
+### UNTESTED
+if [[ "$(uname)" == "Darwin" ]]; then
+memoryBase=`top -l 1 | grep PhysMem: | awk '{print $10  / 1024  / 1024 /  4 }' |cut -f1 -d"."`
+echo $memoryBase
+fi
+
+if [[ "$memoryBase" -lt "1024" ]]; then
+max_connections=200
+shared_buffers=1GB
+effective_cache_size=3GB
+work_mem=5242kB
+maintenance_work_mem=256MB
+min_wal_size=1GB
+max_wal_size=2GB
+checkpoint_completion_target=0.7
+wal_buffers=16MB
+default_statistics_target=100
+update_config
+exit 0
+fi
+
+if [[ "$memoryBase" -lt "2048"  && "$memoryBase" -gt "1024" ]]; then
+max_connections=200
+shared_buffers=2GB
+effective_cache_size=6GB
+work_mem=10485kB
+maintenance_work_mem=512MB
+min_wal_size=1GB
+max_wal_size=2GB
+checkpoint_completion_target=0.7
+wal_buffers=16MB
+default_statistics_target=100
+update_config
+exit 0
+fi
+
+if [[ "$memoryBase" -lt "4096" && "$memoryBase" -gt "2048" ]]; then
+max_connections=200
+shared_buffers=4GB
+effective_cache_size=12GB
+work_mem=20971kB
+maintenance_work_mem=1GB
+min_wal_size=1GB
+max_wal_size=2GB
+checkpoint_completion_target=0.7
+wal_buffers=16MB
+default_statistics_target=100
+update_config
+exit 0
+fi
+
+if [[ "$memoryBase" -lt "8192" && "$memoryBase" -gt "4096" ]]; then
+max_connections=200
+shared_buffers=8GB
+effective_cache_size=24GB
+work_mem=41943kB
+maintenance_work_mem=2GB
+min_wal_size=1GB
+max_wal_size=2GB
+checkpoint_completion_target=0.7
+wal_buffers=16MB
+default_statistics_target=100
+update_config
+exit 0
+fi
+
+if [[ "$memoryBase" -gt "8192" ]]; then
+max_connections=200
+shared_buffers=16GB
+effective_cache_size=48GB
+work_mem=83886kB
+maintenance_work_mem=2GB
+min_wal_size=1GB
+max_wal_size=2GB
+checkpoint_completion_target=0.7
+wal_buffers=16MB
+default_statistics_target=100
+update_config
+exit 0
+fi
+


### PR DESCRIPTION
This commit will add additional logic to the following functions:

start_postgresql: Logic to check if its already running, and a loop to reissue stop commands if it fails to stop, an additional sleep was added to delay the time between postgresql start and lisk start to accomdate reboots

stop_postgresql: Logic to check if postgresql is already stopped and to loop the terminate until it stops.

start_lisk:  added a check to bypass starting lisk if its already running and to warn user that itsalready running
stop lisk: added a check to bypass stopping lisk if its not running and to warn user that its not running

restart case: added the cycle of the database via stop_postgresql and start_postgresql

reload case: net new, added to accommodate config.json changes without needing to stop/start postgresql

Case echo: added reload to the list of options

This commit also imports new objects to support future implementations:

tune.sh - used for tuning database parameters
postgresql.conf - used as the template for database parameters that get replaced by tune.sh
