### PR TITLE
Fixed sources archive unpacking error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ fi
 if [ ! -d "$BUILD_NAME/node_modules" ]; then
   exec_cmd "rm -rf $BUILD_NAME"
   exec_cmd "tar -xvf lisk-source.tar.gz"
-  exec_cmd "mv -f $VERSION $BUILD_NAME"
+  exec_cmd "mv -f lisk-source $BUILD_NAME"
   exec_cmd "cp -vR $POSTGRESQL_DIR/$POSTGRESQL_OUT $BUILD_NAME/"
   exec_cmd "sudo cp -v $BUILD_NAME/pgsql/lib/libpq.* /usr/lib"
   cd "$BUILD_NAME"


### PR DESCRIPTION
Fixed #14 
Sources archive named 'lisk-source.tar.gz' will unpack as 'lick-source', not $VERSION, so it's produces an error when running build.sh. Changed unpacked directory name to 'lick-source'
