### PR TITLE
Fix liskVersion variable return

### DIFF
--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -148,7 +148,7 @@ ntp_checks() {
 }
 
 install_lisk() {
-  liskVersion=`curl -s "https://downloads.lisk.io/lisk/$release/" | grep "$UNAME.tar.gz" | cut -d'"' -f2`
+  liskVersion=`curl -s "https://downloads.lisk.io/lisk/$release/" | grep "$UNAME.tar.gz" | cut -d'"' -f2 | grep -v '\.md5$'`
   liskDir=`echo $liskVersion | cut -d'.' -f1`
 
   echo -e "\nDownloading current Lisk binaries: "$liskVersion


### PR DESCRIPTION
'... | grep "$UNAME.tar.gz" | ...' return two lines, because a .md5 file of package.
The grep added fix this.
