### PR TITLE
Implementing Uptime Snapshotting

### DIFF
--- a/etc/snapshot.json
+++ b/etc/snapshot.json
@@ -1,0 +1,63 @@
+{
+    "port": 9000,
+    "address": "0.0.0.0",
+    "serveHttpAPI": false,
+    "serveHttpWallet": false,
+    "version": "snapshot",
+    "fileLogLevel": "info",
+    "logFileName": "logs/lisk_snapshot.log",
+    "consoleLogLevel": "log",
+    "db": {
+        "host": "localhost",
+        "port": 5432,
+        "database": "lisk_snapshot",
+        "user": null,
+        "password": "password",
+        "poolSize": 20,
+        "poolIdleTimeout": 30000,
+        "reapIntervalMillis": 1000,
+        "logEvents": [
+            "error"
+        ]
+    },
+    "api": {
+        "access": {
+            "whiteList": ["127.0.0.1"]
+        }
+    },
+    "peers": {
+        "list": [],
+        "blackList": [],
+        "options": {
+            "timeout": 4000
+        }
+    },
+    "forging": {
+        "force": false,
+        "secret": [],
+        "access": {
+            "whiteList": [
+                "127.0.0.1"
+            ]
+        }
+    },
+    "loading": {
+        "verifyOnLoading": false,
+        "loadPerIteration": 101
+    },
+    "ssl": {
+        "enabled": false,
+        "options": {
+            "port": 443,
+            "address": "0.0.0.0",
+            "key": "./ssl/lisk.key",
+            "cert": "./ssl/lisk.crt"
+        }
+    },
+    "dapp": {
+        "masterrequired": false,
+        "masterpassword": "notrequired",
+        "autoexec": []
+    },
+    "nethash": "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba"
+}

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -50,6 +50,7 @@ network() {
     NETWORK="local"
   fi
 }
+
 create_user() {
   dropuser --if-exists "$DB_USER" &> /dev/null
   createuser --createdb "$DB_USER" &> /dev/null
@@ -196,7 +197,7 @@ else
   if [ $? == 0 ]; then
     echo "√ Lisk started successfully in snapshot mode."
   else
-    echo "X Failed to start lisk."
+    echo "X Failed to start Lisk."
   fi
 fi
 }
@@ -209,10 +210,10 @@ start_lisk() {
     forever start -u lisk -a -l $LOG_FILE --pidFile $PID_FILE -m 1 app.js -c $LISK_CONFIG &> /dev/null
     if [ $? == 0 ]; then
       echo "√ Lisk started successfully."
-      sleep 1
+      sleep 3
       check_status
     else
-      echo "X Failed to start lisk."
+      echo "X Failed to start Lisk."
     fi
   fi
 }
@@ -223,7 +224,7 @@ stop_lisk() {
     while [[ $stopLisk < 5 ]] &> /dev/null; do
       forever stop -t $PID --killSignal=SIGTERM &> /dev/null
       if [ $? !=  0 ]; then
-        echo "X Failed to stop lisk."
+        echo "X Failed to stop Lisk."
       else
         echo "√ Lisk stopped successfully."
         break
@@ -241,14 +242,14 @@ rebuild_lisk() {
   if [ "$DB_SNAPSHOT" = "blockchain.db.gz" ]; then
     download_blockchain
   else
-    echo -e "√ Using Local Snapshot"
+    echo -e "√ Using Local Snapshot."
   fi
   restore_blockchain
 }
 
 check_status() {
   if [ -f "$PID_FILE" ]; then
-    PID="$(cat "$PID_FILE")""
+    PID="$(cat "$PID_FILE")"
   fi
   if [ ! -z "$PID" ]; then
     ps -p "$PID" > /dev/null 2>&1
@@ -257,7 +258,7 @@ check_status() {
     STATUS=1
   fi
   if [ -f $PID_FILE ] && [ ! -z "$PID" ] && [ $STATUS == 0 ]; then
-    echo "√ Lisk is running as PID: $PID."
+    echo "√ Lisk is running as PID: $PID"
     blockheight
     return 0
   else

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -86,7 +86,7 @@ populate_database() {
 download_blockchain() {
   echo "Downloading blockchain snapshot..."
   rm -f blockchain.*
-  curl -o blockchain.db.gz "https://downloads.lisk.io/lisk/$NETWORK/blockchain.db.gz" &> /dev/null
+  curl --progress-bar -o blockchain.db.gz "https://downloads.lisk.io/lisk/$NETWORK/blockchain.db.gz"
   if [ $? != 0 ]; then
     rm -f blockchain.*
     echo "X Failed to download blockchain snapshot."

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -14,23 +14,11 @@ if [ "$USER" == "root" ]; then
   exit 1
 fi
 
-
-
 UNAME=$(uname)
 LISK_CONFIG=config.json
 
-if [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" ];then
-  NETWORK="test"
-elif [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" ];then
-  NETWORK="main"
-else
-  NETWORK="local"
-fi
-
 LOGS_DIR="$(pwd)/logs"
 PIDS_DIR="$(pwd)/pids"
-
-
 
 DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
 DB_USER=$USER
@@ -53,6 +41,15 @@ blockheight() {
   echo -e "Current Block Height:"$HEIGHT
 }
 
+network() {
+  if [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" ];then
+    NETWORK="test"
+  elif [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" ];then
+    NETWORK="main"
+  else
+    NETWORK="local"
+  fi
+}
 create_user() {
   dropuser --if-exists "$DB_USER" &> /dev/null
   createuser --createdb "$DB_USER" &> /dev/null
@@ -309,7 +306,7 @@ parse_option() {
 
    c) if [ -f $OPTARG ]; then
           LISK_CONFIG=$OPTARG
-          DB_NAME=`grep "database" $LISK_CONFIG | cut -f 4 -d '"'`
+          DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
           LOG_FILE="$LOGS_DIR/$DB_NAME.app.log"
           PID_FILE="$PIDS_DIR/$DB_NAME.pid"
         else
@@ -332,6 +329,7 @@ parse_option() {
 }
 
 parse_option $@
+network
 
 case $1 in
 "coldstart")

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -257,7 +257,7 @@ check_status() {
     STATUS=1
   fi
   if [ -f $PID_FILE ] && [ ! -z "$PID" ] && [ $STATUS == 0 ]; then
-    echo "√ Lisk is running as PID: $PID)."
+    echo "√ Lisk is running as PID: $PID."
     blockheight
     return 0
   else

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -248,7 +248,7 @@ rebuild_lisk() {
 
 check_status() {
   if [ -f "$PID_FILE" ]; then
-    PID=$(cat "$PID_FILE")
+    PID="$(cat "$PID_FILE")""
   fi
   if [ ! -z "$PID" ]; then
     ps -p "$PID" > /dev/null 2>&1
@@ -280,7 +280,7 @@ help() {
   echo -e "stop_node\t\tStops a Nodejs process for Lisk"
   echo -e "stop\t\t\tStop the Nodejs process and PostgreSQL Database for Lisk"
   echo -e "reload\t\t\tRestarts the Nodejs process for Lisk"
-  echo -e "rebuild\t\t\tRebuilds the PostgreSQL database"
+  echo -e "rebuild (-f file.db.gz)\tRebuilds the PostgreSQL database"
   echo -e "start_db\t\tStarts the PostgreSQL database"
   echo -e "stop_db\t\t\tStops the PostgreSQL database"
   echo -e "coldstart\t\tCreates the PostgreSQL database and configures config.json for Lisk"

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -42,9 +42,9 @@ blockheight() {
 }
 
 network() {
-  if [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" ];then
+  if [ "$(grep "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" $LISK_CONFIG )" ];then
     NETWORK="test"
-  elif [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" ];then
+  elif [ "$(grep "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" $LISK_CONFIG )" ];then
     NETWORK="main"
   else
     NETWORK="local"

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -26,6 +26,7 @@ DB_PASS="password"
 DB_DATA="$(pwd)/pgsql/data"
 DB_LOG_FILE="$LOGS_DIR/pgsql.log"
 DB_SNAPSHOT="blockchain.db.gz"
+DB_DOWNLOAD=Y
 
 LOG_FILE="$LOGS_DIR/$DB_NAME.app.log"
 PID_FILE="$PIDS_DIR/$DB_NAME.pid"
@@ -239,7 +240,7 @@ stop_lisk() {
 
 rebuild_lisk() {
   create_database
-  if [ "$DB_SNAPSHOT" = "blockchain.db.gz" ]; then
+  if [ "$DB_DOWNLOAD" = "Y" ]; then
     download_blockchain
   else
     echo -e "√ Using Local Snapshot."
@@ -295,7 +296,7 @@ help() {
 parse_option() {
 
  OPTIND=2
- while getopts ":s:c:f:" opt
+ while getopts ":s:c:f:" opt;
  do
    case $opt in
    s)   if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
@@ -317,6 +318,7 @@ parse_option() {
 
     f) if [ -f $OPTARG ]; then
         DB_SNAPSHOT=$OPTARG
+        DB_DOWNLOAD=N
       else
         echo "Snapshot not found. Please verify the file exists and try again."
       fi ;;

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -15,9 +15,9 @@ mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
 find $BACKUP_LOCATION -name lisk_backup* -mtime +$TIME_TO_KEEP -exec rm {} \;
 
-if [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" ];then
+if [ "$(grep "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" $LISK_CONFIG )" ];then
   NETWORK="test"
-elif [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" ];then
+elif [ "$(grep "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" $LISK_CONFIG )" ];then
   NETWORK="main"
 else
   NETWORK="local"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -1,19 +1,86 @@
 #!/bin/bash
 
+#Begin Variable Declaration and argument parsing
+###############################################################################
+
 cd "$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 . "$(pwd)/shared.sh"
 . "$(pwd)/env.sh"
 
 SNAPSHOT_CONFIG="snapshot.json"
 LISK_CONFIG="config.json"
-BACKUP_LOCATION="./backups/"
-TIME_TO_KEEP="7"
+BACKUP_LOCATION="./backups"
+LOG_LOCATION="$(grep "logFileName" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+DAYS_TO_KEEP="7"
+DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+
+parse_option() {
+
+ OPTIND=1
+ while getopts :s:c:b:d: opt;
+ do
+   case $opt in
+   s) if [ -f $OPTARG ]; then
+          SNAPSHOT_CONFIG=$OPTARG
+          DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+          LOG_LOCATION="$(grep "logFileName" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+      else
+          echo "Config.json for snapshot not found. Please verify the file exists and try again."
+          exit 1
+      fi ;;
+
+   c) if [ -f $OPTARG ]; then
+          LISK_CONFIG=$OPTARG
+          DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
+      else
+          echo "Config.json not found. Please verify the file exists and try again."
+          exit 1
+      fi ;;
+
+    b) mkdir -p $OPTARG  &> /dev/null
+       if [ -d $OPTARG ]; then
+         BACKUP_LOCATION=$OPTARG
+       else
+         echo "Backup Location invalid. Please verify the folder exists and try again."
+         exit 1
+       fi ;;
+
+    d) if [ $OPTARG -ge 0 ]; then
+        DAYS_TO_KEEP=$OPTARG
+       else
+        echo "Invalid number for days to keep."
+        exit 1
+       fi ;;
+    ?) usage; exit 1 ;;
+
+   :) echo "Missing option argument for -$OPTARG" >&2; exit 1 ;;
+
+   *) echo "Unimplemented option: -$OPTARG" >&2; exit 1 ;;
+
+   esac
+ done
+
+}
+
+usage() {
+
+  echo "Usage: $0 [-s <snapshot.json>] [-c <config.json>] [-b <backup directory>] [-d <days to keep>]"
+  echo " -s <snapshot.json>        -- config.json to copy to"
+  echo " -c <config.json>          -- config.json to copy from"
+  echo " -b <backup directory>     -- backup direcory"
+  echo " -d <days to keep>         -- Days to keep backups"
+}
+
+parse_option "$@"
+
+#Begin Main Process
+###############################################################################
 
 echo -e "\nPreparing to take a snapshot of the blockchain."
 
 mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
-find $BACKUP_LOCATION -name lisk_backup* -mtime +$TIME_TO_KEEP -exec rm {} \;
+find $BACKUP_LOCATION -name lisk_backup* -mtime +$DAYS_TO_KEEP -exec rm {} \;
 
 if [ "$(grep "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" $LISK_CONFIG )" ];then
   NETWORK="test"
@@ -22,8 +89,6 @@ elif [ "$(grep "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511
 else
   NETWORK="local"
 fi
-
-DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
 
 echo -e "\nClearing old snapshot instance"
 
@@ -34,12 +99,12 @@ echo -e "\nExporting active database to snapshot instance"
 pg_dump lisk_$NETWORK | psql "$DB_NAME" &> /dev/null
 
 echo -e "\nClearing old log files"
-cat /dev/null > ./logs/lisk_snapshot.log
+cat /dev/null > $LOG_LOCATION
 
 echo -e "\nBeginning snapshot verification process at "$(date)""
 bash lisk.sh snapshot -s 100000 -c snapshot.json
 
-until tail -n10 ./logs/lisk_snapshot.log | grep -q "Cleaned up successfully"; do
+until tail -n10 $LOG_LOCATION | grep -q "Cleaned up successfully"; do
   sleep 60
   ###TODO CHECK IF SNAPSHOT FAILS
 done
@@ -51,6 +116,6 @@ psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null
 HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;')"
 
 echo -e "\nDumping snapshot"
-pg_dump -O "$DB_NAME" | gzip > ./backups/lisk_backup-"$(echo $HEIGHT)".gz
+pg_dump -O "$DB_NAME" | gzip > $BACKUP_LOCATION/lisk_backup-"$(echo $HEIGHT)".gz
 
 echo -e "\nSnapshot Complete"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+cd "$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
+. "$(pwd)/shared.sh"
+. "$(pwd)/env.sh"
+
+SNAPSHOT_CONFIG="snapshot.json"
+LISK_CONFIG="config.json"
+BACKUP_LOCATION="./backups/"
+TIME_TO_KEEP="7"
+
+echo -e "\nPreparing to take a snapshot of the blockchain."
+
+mkdir -p $BACKUP_LOCATION  &> /dev/null
+echo -e "\nClearing old snapshots on disk"
+find $BACKUP_LOCATION -name lisk_backup* -mtime +$TIME_TO_KEEP -exec rm {} \;
+
+if [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" ];then
+  NETWORK="test"
+elif [ "$(grep "nethash" $LISK_CONFIG | cut -f 4 -d '"')" = "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" ];then
+  NETWORK="main"
+else
+  NETWORK="local"
+fi
+
+DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+
+echo -e "\nClearing old snapshot instance"
+
+dropdb --if-exists "$DB_NAME" &> /dev/null
+createdb "$DB_NAME" &> /dev/null
+
+echo -e "\nExporting active database to snapshot instance"
+pg_dump lisk_$NETWORK | psql "$DB_NAME" &> /dev/null
+
+echo -e "\nCleaing old log files"
+cat /dev/null > ./logs/lisk_snapshot.log
+
+echo -e "\nBeginning snapshot process at "$(date)""
+bash lisk.sh snapshot -s 100000 -c snapshot.json
+
+until tail -n10 ./logs/lisk_snapshot.log | grep -q "Cleaned up successfully"; do
+  sleep 60
+  ###TODO CHECK IF SNAPSHOT FAILS
+done
+echo -e "\nSnapshot process completed at "$(date)""
+
+
+echo -e "\nCleaning peers table"
+psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null
+
+HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;')"
+
+echo -e "\nDumping snapshot"
+pg_dump -O "$DB_NAME" | gzip > ./backups/lisk_backup-"$(echo $HEIGHT)".gz
+
+echo "\nSnapshot Complete"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -8,30 +8,34 @@ cd "$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 . "$(pwd)/env.sh"
 
 SNAPSHOT_CONFIG="snapshot.json"
-LISK_CONFIG="config.json"
-BACKUP_LOCATION="./backups"
+TARGET_DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
 LOG_LOCATION="$(grep "logFileName" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+
+LISK_CONFIG="config.json"
+SOURCE_DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
+
+BACKUP_LOCATION="./backups"
+
 DAYS_TO_KEEP="7"
-DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
 
 parse_option() {
 
  OPTIND=1
- while getopts :s:c:b:d: opt;
+ while getopts :s:t:b:d: opt;
  do
    case $opt in
-   s) if [ -f $OPTARG ]; then
+   t) if [ -f $OPTARG ]; then
           SNAPSHOT_CONFIG=$OPTARG
-          DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
+          TARGET_DB_NAME="$(grep "database" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
           LOG_LOCATION="$(grep "logFileName" $SNAPSHOT_CONFIG | cut -f 4 -d '"')"
       else
           echo "Config.json for snapshot not found. Please verify the file exists and try again."
           exit 1
       fi ;;
 
-   c) if [ -f $OPTARG ]; then
+   s) if [ -f $OPTARG ]; then
           LISK_CONFIG=$OPTARG
-          DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
+          SOURCE_DB_NAME="$(grep "database" $LISK_CONFIG | cut -f 4 -d '"')"
       else
           echo "Config.json not found. Please verify the file exists and try again."
           exit 1
@@ -64,11 +68,12 @@ parse_option() {
 
 usage() {
 
-  echo "Usage: $0 [-s <snapshot.json>] [-c <config.json>] [-b <backup directory>] [-d <days to keep>]"
-  echo " -s <snapshot.json>        -- config.json to use for validation"
-  echo " -c <config.json>          -- config.json to create target database"
+  echo "Usage: $0 [-s <config.json>] [-t <snapshot.json>] [-b <backup directory>] [-d <days to keep>]"
+  echo " -t <snapshot.json>        -- config.json to use for validation"
+  echo " -s <config.json>          -- config.json to create target database"
   echo " -b <backup directory>     -- backup direcory"
   echo " -d <days to keep>         -- Days to keep backups"
+
 }
 
 parse_option "$@"
@@ -82,21 +87,13 @@ mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
 find $BACKUP_LOCATION -name lisk_backup* -mtime +$DAYS_TO_KEEP -exec rm {} \;
 
-if [ "$(grep "da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba" $LISK_CONFIG )" ];then
-  NETWORK="test"
-elif [ "$(grep "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511" $LISK_CONFIG )" ];then
-  NETWORK="main"
-else
-  NETWORK="local"
-fi
-
 echo -e "\nClearing old snapshot instance"
 
-dropdb --if-exists "$DB_NAME" &> /dev/null
-createdb "$DB_NAME" &> /dev/null
+dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
+createdb "$TARGET_DB_NAME" &> /dev/null
 
 echo -e "\nExporting active database to snapshot instance"
-pg_dump lisk_$NETWORK | psql "$DB_NAME" &> /dev/null
+pg_dump $SOURCE_DB_NAME | psql "$TARGET_DB_NAME" &> /dev/null
 
 echo -e "\nClearing old log files"
 cat /dev/null > $LOG_LOCATION
@@ -116,6 +113,6 @@ psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null
 HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;')"
 
 echo -e "\nDumping snapshot"
-pg_dump -O "$DB_NAME" | gzip > $BACKUP_LOCATION/lisk_backup-"$(echo $HEIGHT)".gz
+pg_dump -O "$TARGET_DB_NAME" | gzip > $BACKUP_LOCATION/lisk_backup-"$(echo $HEIGHT)".gz
 
 echo -e "\nSnapshot Complete"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -65,8 +65,8 @@ parse_option() {
 usage() {
 
   echo "Usage: $0 [-s <snapshot.json>] [-c <config.json>] [-b <backup directory>] [-d <days to keep>]"
-  echo " -s <snapshot.json>        -- config.json to copy to"
-  echo " -c <config.json>          -- config.json to copy from"
+  echo " -s <snapshot.json>        -- config.json to use for validation"
+  echo " -c <config.json>          -- config.json to create target database"
   echo " -b <backup directory>     -- backup direcory"
   echo " -d <days to keep>         -- Days to keep backups"
 }

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -33,7 +33,7 @@ createdb "$DB_NAME" &> /dev/null
 echo -e "\nExporting active database to snapshot instance"
 pg_dump lisk_$NETWORK | psql "$DB_NAME" &> /dev/null
 
-echo -e "\nCleaing old log files"
+echo -e "\nClearing old log files"
 cat /dev/null > ./logs/lisk_snapshot.log
 
 echo -e "\nBeginning snapshot process at "$(date)""
@@ -44,7 +44,8 @@ until tail -n10 ./logs/lisk_snapshot.log | grep -q "Cleaned up successfully"; do
   ###TODO CHECK IF SNAPSHOT FAILS
 done
 echo -e "\nSnapshot process completed at "$(date)""
-
+PID="$(bash lisk.sh status -c snapshot.json| grep PID| cut -d: -f 2)"
+kill -9 $PID
 
 echo -e "\nCleaning peers table"
 psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -36,16 +36,14 @@ pg_dump lisk_$NETWORK | psql "$DB_NAME" &> /dev/null
 echo -e "\nClearing old log files"
 cat /dev/null > ./logs/lisk_snapshot.log
 
-echo -e "\nBeginning snapshot process at "$(date)""
+echo -e "\nBeginning snapshot verification process at "$(date)""
 bash lisk.sh snapshot -s 100000 -c snapshot.json
 
 until tail -n10 ./logs/lisk_snapshot.log | grep -q "Cleaned up successfully"; do
   sleep 60
   ###TODO CHECK IF SNAPSHOT FAILS
 done
-echo -e "\nSnapshot process completed at "$(date)""
-PID="$(bash lisk.sh status -c snapshot.json| grep PID| cut -d: -f 2)"
-kill -9 $PID
+echo -e "\nSnapshot verification process completed at "$(date)""
 
 echo -e "\nCleaning peers table"
 psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null
@@ -55,4 +53,4 @@ HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height
 echo -e "\nDumping snapshot"
 pg_dump -O "$DB_NAME" | gzip > ./backups/lisk_backup-"$(echo $HEIGHT)".gz
 
-echo "\nSnapshot Complete"
+echo -e "\nSnapshot Complete"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -83,12 +83,14 @@ parse_option "$@"
 
 echo -e "\nPreparing to take a snapshot of the blockchain."
 
+
+
 mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
 find $BACKUP_LOCATION -name lisk_backup* -mtime +$DAYS_TO_KEEP -exec rm {} \;
 
 echo -e "\nClearing old snapshot instance"
-
+bash lisk.sh stop_node -c $SNAPSHOT_CONFIG &> /dev/null
 dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
 createdb "$TARGET_DB_NAME" &> /dev/null
 
@@ -99,7 +101,7 @@ echo -e "\nClearing old log files"
 cat /dev/null > $LOG_LOCATION
 
 echo -e "\nBeginning snapshot verification process at "$(date)""
-bash lisk.sh snapshot -s 100000 -c snapshot.json
+bash lisk.sh snapshot -s 100000 -c $SNAPSHOT_CONFIG
 
 until tail -n10 $LOG_LOCATION | grep -q "Cleaned up successfully"; do
   sleep 60

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -44,7 +44,8 @@ until tail -n10 ./logs/lisk_snapshot.log | grep -q "Cleaned up successfully"; do
   ###TODO CHECK IF SNAPSHOT FAILS
 done
 echo -e "\nSnapshot process completed at "$(date)""
-
+PID="$(bash lisk.sh status -c snapshot.json| grep PID| cut -d: -f 2)"
+kill -9 $PID
 
 echo -e "\nCleaning peers table"
 psql -d lisk_snapshot -c 'delete from peers;'  &> /dev/null


### PR DESCRIPTION
Contained in this pull request are 2 file additions and changes to lisk.sh

etc/snapshot.json

This file will reside in the root of $LISK_HOME and provide the backbone for executing Lisk in snapshot mode. It works on port 9000 and uses a new database instance, lisk_snapshot.

scripts/lisk_snapshot.sh

This is the core of this change. This new script allows any user to run a snapshot in uptime and automatically create a backup upon successful completion of the program. 

scripts/lisk.sh

These changse are necessary to allow for the use of community and personally created snapshots. This will promote decentralization of maintaining the blockchain database.
QOL change for includes displaying process ID after starting Lisk and the blockchain height.
Network option is now in a function that reads config.json removing the need for manual adjustment on testnet vs mainnet clients
