### PR TITLE
Corrections for snapshot flag

### DIFF
--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -303,8 +303,10 @@ parse_option() {
       s)
         if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
           SNAPSHOT=$OPTARG
+        elif [ "$OPTARG" == "highest" ]; then
+          SNAPSHOT=$OPTARG
         else
-          echo "Snapshot flag must be a number and greater than 0"
+          echo "Snapshot flag must be a greater than 0 or set to highest"
           exit 1
         fi ;;
 

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -102,7 +102,7 @@ echo -e "\nPreparing to take a snapshot of the blockchain."
 
 mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
-find $BACKUP_LOCATION -name "*.gz" -mtime +$DAYS_TO_KEEP -exec rm {} \;
+find $BACKUP_LOCATION -name "${TARGET_DB_NAME}*.gz" -mtime +$DAYS_TO_KEEP -exec rm {} \;
 
 echo -e "\nClearing old snapshot instance"
 bash lisk.sh stop_node -c $SNAPSHOT_CONFIG &> /dev/null

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -18,9 +18,11 @@ BACKUP_LOCATION="./backups"
 
 DAYS_TO_KEEP="7"
 
+SNAPSHOT_ROUND="highest"
+
 parse_option() {
   OPTIND=1
-  while getopts :s:t:b:d: opt; do
+  while getopts :s:t:b:d:r: opt; do
     case $opt in
       t)
         if [ -f $OPTARG ]; then
@@ -58,6 +60,16 @@ parse_option() {
           exit 1
         fi ;;
 
+      r)
+        if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
+          SNAPSHOT=$OPTARG
+        elif [ "$OPTARG" == "highest" ]; then
+          SNAPSHOT=$OPTARG
+        else
+          echo "Snapshot flag must be a greater than 0 or set to highest"
+          exit 1
+        fi ;;
+
       ?) usage; exit 1 ;;
 
       :) echo "Missing option argument for -$OPTARG" >&2; exit 1 ;;
@@ -68,11 +80,12 @@ parse_option() {
 }
 
 usage() {
-  echo "Usage: $0 [-s <config.json>] [-t <snapshot.json>] [-b <backup directory>] [-d <days to keep>]"
+  echo "Usage: $0 [-t <snapshot.json>] [-s <config.json>] [-b <backup directory>] [-d <days to keep>] [-r <round>]"
   echo " -t <snapshot.json>        -- config.json to use for validation"
   echo " -s <config.json>          -- config.json to create target database"
-  echo " -b <backup directory>     -- backup direcory"
+  echo " -b <backup directory>     -- Backup direcory"
   echo " -d <days to keep>         -- Days to keep backups"
+  echo " -r <round>                -- Round height to snapshot at"
 }
 
 parse_option "$@"
@@ -98,7 +111,7 @@ echo -e "\nClearing old log files"
 cat /dev/null > $LOG_LOCATION
 
 echo -e "\nBeginning snapshot verification process at "$(date)""
-bash lisk.sh snapshot -s highest -c $SNAPSHOT_CONFIG
+bash lisk.sh snapshot -s $SNAPSHOT_ROUND -c $SNAPSHOT_CONFIG
 
 until tail -n10 $LOG_LOCATION | grep -q "Cleaned up successfully"; do
   sleep 60

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -102,7 +102,7 @@ echo -e "\nPreparing to take a snapshot of the blockchain."
 
 mkdir -p $BACKUP_LOCATION  &> /dev/null
 echo -e "\nClearing old snapshots on disk"
-find $BACKUP_LOCATION -name "${TARGET_DB_NAME}*.gz" -mtime +$DAYS_TO_KEEP -exec rm {} \;
+find $BACKUP_LOCATION -name "${SOURCE_DB_NAME}*.gz" -mtime +$DAYS_TO_KEEP -exec rm {} \;
 
 echo -e "\nClearing old snapshot instance"
 bash lisk.sh stop_node -c $SNAPSHOT_CONFIG &> /dev/null
@@ -129,7 +129,7 @@ psql -d $TARGET_DB_NAME -c 'delete from peers;'  &> /dev/null
 
 HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;' | xargs)"
 
-BACKUP_FULLPATH="${BACKUP_LOCATION}/${TARGET_DB_NAME}_backup-${HEIGHT}.gz"
+BACKUP_FULLPATH="${BACKUP_LOCATION}/${SOURCE_DB_NAME}_backup-${HEIGHT}.gz"
 
 echo -e "\nDumping snapshot"
 pg_dump -O "$TARGET_DB_NAME" | gzip > $BACKUP_FULLPATH


### PR DESCRIPTION
Pull request addresses #40 and #39

Corrects logic to allow highest string
Adds logic to lisk_snapshot.sh to allow specifying round height
Adds empty blockchain.db.gz to allow rebuild from 0
Adds logic to allow generic named snapshot of blockchain.db.gz to be generated by lisk_snapshot.sh. Primarily used for generating revolving hosted backups @Gr33nDrag0n69 
