### PR TITLE
Update md5 command on mac os x

### DIFF
--- a/patches/FreeBSD/amd64/node/0005-Patching-common.gypi.patch
+++ b/patches/FreeBSD/amd64/node/0005-Patching-common.gypi.patch
@@ -1,0 +1,24 @@
+From 74da03e5df83770d554604391ce2858f815da7d2 Mon Sep 17 00:00:00 2001
+From: Oliver Beddows <oliver@lisk.io>
+Date: Mon, 10 Oct 2016 09:13:55 +0000
+Subject: [PATCH] Patching common.gypi.
+
+---
+ common.gypi | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/common.gypi b/common.gypi
+index 1984fa8..8a57cea 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -182,7 +182,6 @@
+       [ 'OS in "linux freebsd openbsd solaris android"', {
+         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+         'cflags_cc': [
+-          '-fno-delete-null-pointer-checks',
+           '-fno-exceptions',
+           '-fno-rtti',
+         ],
+-- 
+2.8.1
+

--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -206,7 +206,7 @@ install_lisk() {
   elif [[ "$(uname)" == "FreeBSD" ]]; then
     md5=`md5 $liskVersion | awk '{print $1}'`
   elif [[ "$(uname)" == "Darwin" ]]; then
-    md5=`md5 $liskVersion | awk '{print $1}'`
+    md5=`md5 $liskVersion | awk '{print $4}'`
   fi
 
   md5_compare=`grep "$liskVersion" $liskVersion.md5 | awk '{print $1}'`

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -38,7 +38,8 @@ check_cmds CMDS[@]
 ################################################################################
 
 blockheight() {
-  HEIGHT="$(psql -d $DB_NAME -t -c 'select height from blocks order by height desc limit 1;')"
+  DB_HEIGHT="$(psql -d $DB_NAME -t -c 'select height from blocks order by height desc limit 1;')"
+  HEIGHT="${DB_HEIGHT:- Unavailable}"
   echo -e "Current Block Height:"$HEIGHT
 }
 

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -87,7 +87,7 @@ usage() {
   echo "Usage: $0 [-t <snapshot.json>] [-s <config.json>] [-b <backup directory>] [-d <days to keep>] [-r <round>] [-g]"
   echo " -t <snapshot.json>        -- config.json to use for validation"
   echo " -s <config.json>          -- config.json to create target database"
-  echo " -b <backup directory>     -- Backup direcory"
+  echo " -b <backup directory>     -- Backup directory"
   echo " -d <days to keep>         -- Days to keep backups"
   echo " -r <round>                -- Round height to snapshot at"
   echo " -g                        -- Make a copy of backup file named blockchain.db.gz"


### PR DESCRIPTION
https://github.com/Doweig/lisk-build/edit/development/release/installLisk.sh#L209

Md5 output on Mac looks like this:

`MD5 (Makefile) = 8df5b28ea83e381a01e2f96bc35282b4`

Should be `$4` not `$1`
