### PR TITLE
lisk_snapshot.sh update take2

### DIFF
--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -130,7 +130,7 @@ usage() {
 }
 
 now() {
-  echo "$( date +'%Y-%m-%d %H:%M:%S' )"
+  date +'%Y-%m-%d %H:%M:%S'
 }
 
 

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-# Begin Variable Declaration and argument parsing
-###############################################################################
+### Init. Env. ################################################################
 
 cd "$(cd -P -- "$(dirname -- "$0")" && pwd -P)" || exit 2
 # shellcheck disable=SC1090
 . "$(pwd)/shared.sh"
 # shellcheck disable=SC1090
 . "$(pwd)/env.sh"
+
+
+### Variables Definition ######################################################
 
 SNAPSHOT_CONFIG="$(pwd)/etc/snapshot.json"
 TARGET_DB_NAME="$(grep "database" "$SNAPSHOT_CONFIG" | cut -f 4 -d '"')"
@@ -24,9 +26,18 @@ SNAPSHOT_ROUND="highest"
 
 GENERIC_COPY="N"
 
+PGSQL_VACUUM="N"
+PGSQL_VACUUM_DELAY=5
+
+STALL_THRESHOLD_PREVIOUS=20
+STALL_THRESHOLD_CURRENT=10
+
+
+### Function(s) ###############################################################
+
 parse_option() {
   OPTIND=1
-  while getopts :s:t:b:d:r:g OPT; do
+  while getopts :t:s:b:d:r:gvm: OPT; do
     case "$OPT" in
       t)
         if [ -f "$OPTARG" ]; then
@@ -34,7 +45,7 @@ parse_option() {
           TARGET_DB_NAME="$(grep "database" "$SNAPSHOT_CONFIG" | cut -f 4 -d '"')"
           LOG_LOCATION="$(grep "logFileName" "$SNAPSHOT_CONFIG" | cut -f 4 -d '"')"
         else
-          echo "Config.json for snapshot not found. Please verify the file exists and try again."
+          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Config.json for snapshot not found. Please verify the file exists and try again."
           exit 1
         fi ;;
 
@@ -43,7 +54,7 @@ parse_option() {
           LISK_CONFIG="$OPTARG"
           SOURCE_DB_NAME="$(grep "database" "$LISK_CONFIG" | cut -f 4 -d '"')"
         else
-          echo "Config.json not found. Please verify the file exists and try again."
+          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Config.json not found. Please verify the file exists and try again."
           exit 1
         fi ;;
 
@@ -52,7 +63,7 @@ parse_option() {
         if [ -d "$OPTARG" ]; then
           BACKUP_LOCATION="$OPTARG"
         else
-          echo "Backup Location invalid. Please verify the folder exists and try again."
+          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Backup Location invalid. Please verify the folder exists and try again."
           exit 1
         fi ;;
 
@@ -63,100 +74,139 @@ parse_option() {
           echo "Invalid number for days to keep."
           exit 1
         fi ;;
-
+		
       r)
         if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
           SNAPSHOT_ROUND="$OPTARG"
         elif [ "$OPTARG" == "highest" ]; then
           SNAPSHOT_ROUND="$OPTARG"
         else
-          echo "Snapshot flag must be a greater than 0 or set to highest"
+          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot flag must be a greater than 0 or set to highest"
           exit 1
         fi ;;
 
       g) GENERIC_COPY="Y" ;;
 
+      v) PGSQL_VACUUM="Y" ;;
+
+      m)
+        if [ "$OPTARG" -ge 1 ]; then
+          PGSQL_VACUUM_DELAY=$OPTARG
+        else
+          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Invalid number for vacuum delay in minute(s)."
+          exit 1
+        fi ;;
+
       ?) usage; exit 1 ;;
+	  
+      :) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Missing option argument for -$OPTARG" >&2; exit 1 ;;
 
-      :) echo 'Missing option argument for -'"$OPTARG" >&2; exit 1 ;;
-
-      *) echo 'Unimplemented option: -'"$OPTARG" >&2; exit 1 ;;
+      *) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Unimplemented option: -$OPTARG" >&2; exit 1 ;;
+	  
     esac
   done
 }
 
 usage() {
-  echo "Usage: $0 [-t <snapshot.json>] [-s <config.json>] [-b <backup directory>] [-d <days to keep>] [-r <round>] [-g]"
+  echo -e "\nUsage: $0 [-t <snapshot.json>] [-s <config.json>] [-b <backup directory>] [-d <days to keep>] [-r <round>] [-g] [-v] [-m <vacuum delay>]\n"
   echo " -t <snapshot.json>        -- config.json to use for creating the snapshot"
   echo " -s <config.json>          -- config.json used by the target database"
-  echo " -b <backup directory>     -- Backup directory to output into"
-  echo " -d <days to keep>         -- Days to keep backups"
-  echo " -r <round>                -- Round to end the snapshot at"
+  echo " -b <backup directory>     -- Backup directory to output into. Default is ./backups"
+  echo " -d <days to keep>         -- Days to keep backups. Default is 7"
+  echo " -r <round>                -- Round to end the snapshot at. Default is highest"
   echo " -g                        -- Make a copy of backup file named blockchain.db.gz"
+  echo " -v                        -- Use extra pgsql vacuum commands"
+  echo " -m <vacuum delay>         -- Delay in minute(s) between each vacuum of mem_round table."
+  echo ''
 }
+
+
+### MAIN ######################################################################
 
 parse_option "$@"
 
-# Begin Main Process
-###############################################################################
-
-echo -e "\nPreparing to take a snapshot of the blockchain."
-
-echo -e "\nChecking for existing snapshot operation"
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Checking for existing snapshot operation"
 
 bash lisk.sh status -c "$SNAPSHOT_CONFIG"
 
 if [ $? == 1 ]; then
   echo "√ Previous snapshot is not runnning. Proceeding."
 else
-    if [ "$(stat --format=%Y "$LOG_LOCATION")" -le $(( $(date +%s) - 86400 )) ]; then
-      echo "Snapshot has run over time limit, terminating and continuing with a new snapshot"
-      bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG"
-    else
+  if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_PREVIOUS * 60 ) )) ]; then
+    echo "√ Previous snapshot is stalled for $STALL_THRESHOLD_PREVIOUS minutes, terminating and continuing with a new snapshot"
+    bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG"
+  else
     echo "X Previous snapshot is in progress, aborting."
     exit 1
   fi
 fi
 
 mkdir -p "$BACKUP_LOCATION" &> /dev/null
-echo -e "\nClearing old snapshots on disk"
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Deleting snapshots older then $DAYS_TO_KEEP day(s) in $BACKUP_LOCATION"
 find "$BACKUP_LOCATION" -name "${SOURCE_DB_NAME}*.gz" -mtime +"$DAYS_TO_KEEP" -exec rm {} \;
 
-echo -e "\nClearing old snapshot instance"
+if [ "$PGSQL_VACUUM" == "Y" ] 2> /dev/null; then
+  echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on database '$SOURCE_DB_NAME' before copy"
+  vacuumdb --analyze --full "$SOURCE_DB_NAME" &> /dev/null
+fi
+
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning old snapshot instance, database and logs"
 bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
 dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
-createdb "$TARGET_DB_NAME" &> /dev/null
-
-echo -e "\nExporting active database to snapshot instance"
-pg_dump "$SOURCE_DB_NAME" | psql "$TARGET_DB_NAME" &> /dev/null
-
-echo -e "\nClearing old log files"
 cat /dev/null > "$LOG_LOCATION"
 
-echo -e '\nBeginning snapshot verification process at '"$(date)"
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Copying active database '$SOURCE_DB_NAME' to snapshot database '$TARGET_DB_NAME'"
+createdb "$TARGET_DB_NAME" &> /dev/null
+pg_dump "$SOURCE_DB_NAME" | psql "$TARGET_DB_NAME" &> /dev/null
+
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Beginning snapshot verification process"
 bash lisk.sh snapshot -s "$SNAPSHOT_ROUND" -c "$SNAPSHOT_CONFIG"
 
+MINUTES=0
 until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
   sleep 60
-  # TODO: Check if snapshot fails
+  
+  if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_CURRENT * 60 ) )) ]; then
+    echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot process is stalled for $STALL_THRESHOLD_CURRENT minutes, cleaning up and exiting"
+	bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
+	dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
+    exit 1
+  fi
+  
+  MINUTES=$(( MINUTES + 1 ))
+  if [ "$PGSQL_VACUUM" == "Y" ] 2> /dev/null; then
+	if (( MINUTES % PGSQL_VACUUM_DELAY == 0 )) 2> /dev/null; then
+      echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on table 'mem_round' of database '$TARGET_DB_NAME'"
+      DBSIZE1=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
+      vacuumdb --analyze --full --table 'mem_round' "$TARGET_DB_NAME" &> /dev/null
+      DBSIZE2=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
+      echo -e "$( date +'%Y-%m-%d %H:%M:%S' ) Vacuum completed, database size: $DBSIZE1 MB => $DBSIZE2 MB"
+	fi
+  fi
 done
-echo -e '\nSnapshot verification process completed at '"$(date)"
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot verification process completed"
 
-echo -e "\nCleaning peers table"
-psql -d "$TARGET_DB_NAME" -c 'delete from peers;'  &> /dev/null
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Deleting data on table 'peers' of database '$TARGET_DB_NAME'"
+psql -d "$TARGET_DB_NAME" -c 'delete from peers;' &> /dev/null
 
+if [ "$PGSQL_VACUUM" == "Y" ] 2> /dev/null; then
+  echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on database '$TARGET_DB_NAME' before dumping"
+  vacuumdb --analyze --full "$TARGET_DB_NAME" &> /dev/null
+fi
+
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Dumping snapshot database to gzip file"
 HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;' | xargs)"
-
 BACKUP_FULLPATH="${BACKUP_LOCATION}/${SOURCE_DB_NAME}_backup-${HEIGHT}.gz"
-
-echo -e "\nDumping snapshot"
 pg_dump -O "$TARGET_DB_NAME" | gzip > "$BACKUP_FULLPATH"
 
 if [ "$GENERIC_COPY" == "Y" ] 2> /dev/null; then
-  echo -e "\nOverwriting Generic Copy"
+  echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Overwriting Generic Copy"
   cp -f "$BACKUP_FULLPATH" "$BACKUP_LOCATION"/blockchain.db.gz &> /dev/null
 fi
 
-echo -e "\nSnapshot Complete, cleaning up forever monitor"
-# Required to clean up terminated forever processes after snapshot
-bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG"
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning up"
+bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
+dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
+
+echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot Complete"
+exit 0

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -136,13 +136,13 @@ parse_option "$@"
 
 echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Checking for existing snapshot operation"
 
-if [ ! -f $LOCK_FILE ]; then
+if [ ! -f "$LOCK_FILE" ]; then
   echo "√ Previous snapshot is not runnning. Proceeding."
 else
   if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_PREVIOUS * 60 ) )) ]; then
     echo "√ Previous snapshot is stalled for $STALL_THRESHOLD_PREVIOUS minutes, terminating and continuing with a new snapshot"
     bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG"
-    rm -f $LOCK_FILE &> /dev/null
+    rm -f "$LOCK_FILE" &> /dev/null
   else
     echo "X Previous snapshot is in progress, aborting."
     exit 1
@@ -150,7 +150,7 @@ else
 fi
 
 mkdir -p "$LOCK_LOCATION" &> /dev/null
-touch $LOCK_FILE &> /dev/null
+touch "$LOCK_FILE" &> /dev/null
 
 echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning old snapshot instance, database and logs"
 bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
@@ -179,7 +179,7 @@ until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
     echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot process is stalled for $STALL_THRESHOLD_CURRENT minutes, cleaning up and exiting"
     bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
     dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
-    rm -f $LOCK_FILE &> /dev/null
+    rm -f "$LOCK_FILE" &> /dev/null
     exit 1
   fi
   
@@ -213,7 +213,7 @@ fi
 echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning up"
 bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
 dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
-rm -f $LOCK_FILE &> /dev/null
+rm -f "$LOCK_FILE" &> /dev/null
 
 echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot Complete"
 exit 0

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -130,7 +130,7 @@ usage() {
 }
 
 now() {
-  echo $( date +'%Y-%m-%d %H:%M:%S' )
+  echo "$( date +'%Y-%m-%d %H:%M:%S' )"
 }
 
 

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -111,7 +111,7 @@ usage() {
   echo " -b <backup directory>     -- Backup directory to output into. Default is ./backups"
   echo " -d <days to keep>         -- Days to keep backups. Default is 7"
   echo " -r <round>                -- Round to end the snapshot at. Default is highest"
-  echo " -m <vacuum delay>         -- Delay in minute(s) between each vacuum of mem_round table."
+  echo " -m <vacuum delay>         -- Delay in minute(s) between each vacuum of mem_round table.  Default is 3"
   echo " -g                        -- Make a copy of backup file named blockchain.db.gz"
   echo ''
 }

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -74,8 +74,8 @@ parse_option() {
           echo "Invalid number for days to keep."
           exit 1
         fi ;;
-		
-      r)
+
+		r)
         if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
           SNAPSHOT_ROUND="$OPTARG"
         elif [ "$OPTARG" == "highest" ]; then
@@ -98,11 +98,11 @@ parse_option() {
         fi ;;
 
       ?) usage; exit 1 ;;
-	  
+
       :) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Missing option argument for -$OPTARG" >&2; exit 1 ;;
 
       *) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Unimplemented option: -$OPTARG" >&2; exit 1 ;;
-	  
+
     esac
   done
 }
@@ -168,20 +168,20 @@ until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
   
   if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_CURRENT * 60 ) )) ]; then
     echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot process is stalled for $STALL_THRESHOLD_CURRENT minutes, cleaning up and exiting"
-	bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
-	dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
+    bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
+    dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
     exit 1
   fi
   
   MINUTES=$(( MINUTES + 1 ))
   if [ "$PGSQL_VACUUM" == "Y" ] 2> /dev/null; then
-	if (( MINUTES % PGSQL_VACUUM_DELAY == 0 )) 2> /dev/null; then
+    if (( MINUTES % PGSQL_VACUUM_DELAY == 0 )) 2> /dev/null; then
       echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on table 'mem_round' of database '$TARGET_DB_NAME'"
       DBSIZE1=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
       vacuumdb --analyze --full --table 'mem_round' "$TARGET_DB_NAME" &> /dev/null
       DBSIZE2=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
       echo -e "$( date +'%Y-%m-%d %H:%M:%S' ) Vacuum completed, database size: $DBSIZE1 MB => $DBSIZE2 MB"
-	fi
+    fi
   fi
 done
 echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot verification process completed"

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -57,7 +57,7 @@ parse_option() {
           TARGET_DB_NAME="$(grep "database" "$SNAPSHOT_CONFIG" | cut -f 4 -d '"')"
           LOG_LOCATION="$(grep "logFileName" "$SNAPSHOT_CONFIG" | cut -f 4 -d '"')"
         else
-          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Config.json for snapshot not found. Please verify the file exists and try again."
+          echo "$(now) Config.json for snapshot not found. Please verify the file exists and try again."
           exit 1
         fi ;;
 
@@ -66,7 +66,7 @@ parse_option() {
           LISK_CONFIG="$OPTARG"
           SOURCE_DB_NAME="$(grep "database" "$LISK_CONFIG" | cut -f 4 -d '"')"
         else
-          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Config.json not found. Please verify the file exists and try again."
+          echo "$(now) Config.json not found. Please verify the file exists and try again."
           exit 1
         fi ;;
 
@@ -75,7 +75,7 @@ parse_option() {
         if [ -d "$OPTARG" ]; then
           BACKUP_LOCATION="$OPTARG"
         else
-          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Backup Location invalid. Please verify the folder exists and try again."
+          echo "$(now) Backup Location invalid. Please verify the folder exists and try again."
           exit 1
         fi ;;
 
@@ -93,7 +93,7 @@ parse_option() {
         elif [ "$OPTARG" == "highest" ]; then
           SNAPSHOT_ROUND="$OPTARG"
         else
-          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot flag must be a greater than 0 or set to highest"
+          echo "$(now) Snapshot flag must be a greater than 0 or set to highest"
           exit 1
         fi ;;
 
@@ -101,7 +101,7 @@ parse_option() {
         if [ "$OPTARG" -ge 1 ]; then
           PGSQL_VACUUM_DELAY=$OPTARG
         else
-          echo "$( date +'%Y-%m-%d %H:%M:%S' ) Invalid number for vacuum delay in minute(s)."
+          echo "$(now) Invalid number for vacuum delay in minute(s)."
           exit 1
         fi ;;
 
@@ -109,9 +109,9 @@ parse_option() {
 
       ?) usage; exit 1 ;;
 
-      :) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Missing option argument for -$OPTARG" >&2; exit 1 ;;
+      :) echo "$(now) Missing option argument for -$OPTARG" >&2; exit 1 ;;
 
-      *) echo "$( date +'%Y-%m-%d %H:%M:%S' ) Unimplemented option: -$OPTARG" >&2; exit 1 ;;
+      *) echo "$(now) Unimplemented option: -$OPTARG" >&2; exit 1 ;;
 
     esac
   done
@@ -129,12 +129,16 @@ usage() {
   echo ''
 }
 
+now() {
+  echo $( date +'%Y-%m-%d %H:%M:%S' )
+}
+
 
 ### MAIN ######################################################################
 
 parse_option "$@"
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Checking for existing snapshot operation"
+echo -e "\n$(now) Checking for existing snapshot operation"
 
 if [ ! -f "$LOCK_FILE" ]; then
   echo "√ Previous snapshot is not runnning. Proceeding."
@@ -152,23 +156,23 @@ fi
 mkdir -p "$LOCK_LOCATION" &> /dev/null
 touch "$LOCK_FILE" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning old snapshot instance, database and logs"
+echo -e "\n$(now) Cleaning old snapshot instance, database and logs"
 bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
 cat /dev/null > "$LOG_LOCATION"
 dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Deleting snapshots older then $DAYS_TO_KEEP day(s) in $BACKUP_LOCATION"
+echo -e "\n$(now) Deleting snapshots older then $DAYS_TO_KEEP day(s) in $BACKUP_LOCATION"
 mkdir -p "$BACKUP_LOCATION" &> /dev/null
 find "$BACKUP_LOCATION" -name "${SOURCE_DB_NAME}*.gz" -mtime +"$DAYS_TO_KEEP" -exec rm {} \;
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on database '$SOURCE_DB_NAME' before copy"
+echo -e "\n$(now) Executing vacuum on database '$SOURCE_DB_NAME' before copy"
 vacuumdb --analyze --full "$SOURCE_DB_NAME" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Copying active database '$SOURCE_DB_NAME' to snapshot database '$TARGET_DB_NAME'"
+echo -e "\n$(now) Copying active database '$SOURCE_DB_NAME' to snapshot database '$TARGET_DB_NAME'"
 createdb "$TARGET_DB_NAME" &> /dev/null
 pg_dump "$SOURCE_DB_NAME" | psql "$TARGET_DB_NAME" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Beginning snapshot verification process"
+echo -e "\n$(now) Beginning snapshot verification process"
 bash lisk.sh snapshot -s "$SNAPSHOT_ROUND" -c "$SNAPSHOT_CONFIG"
 
 MINUTES=0
@@ -176,7 +180,7 @@ until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
   sleep 60
   
   if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_CURRENT * 60 ) )) ]; then
-    echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot process is stalled for $STALL_THRESHOLD_CURRENT minutes, cleaning up and exiting"
+    echo -e "\n$(now) Snapshot process is stalled for $STALL_THRESHOLD_CURRENT minutes, cleaning up and exiting"
     bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
     dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
     rm -f "$LOCK_FILE" &> /dev/null
@@ -185,35 +189,35 @@ until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
   
   MINUTES=$(( MINUTES + 1 ))
   if (( MINUTES % PGSQL_VACUUM_DELAY == 0 )) 2> /dev/null; then
-    echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on table 'mem_round' of database '$TARGET_DB_NAME'"
+    echo -e "\n$(now) Executing vacuum on table 'mem_round' of database '$TARGET_DB_NAME'"
     DBSIZE1=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
     vacuumdb --analyze --full --table 'mem_round' "$TARGET_DB_NAME" &> /dev/null
     DBSIZE2=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
-    echo -e "$( date +'%Y-%m-%d %H:%M:%S' ) Vacuum completed, database size: $DBSIZE1 MB => $DBSIZE2 MB"
+    echo -e "$(now) Vacuum completed, database size: $DBSIZE1 MB => $DBSIZE2 MB"
   fi
 done
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot verification process completed"
+echo -e "\n$(now) Snapshot verification process completed"
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Deleting data on table 'peers' of database '$TARGET_DB_NAME'"
+echo -e "\n$(now) Deleting data on table 'peers' of database '$TARGET_DB_NAME'"
 psql -d "$TARGET_DB_NAME" -c 'delete from peers;' &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Executing vacuum on database '$TARGET_DB_NAME' before dumping"
+echo -e "\n$(now) Executing vacuum on database '$TARGET_DB_NAME' before dumping"
 vacuumdb --analyze --full "$TARGET_DB_NAME" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Dumping snapshot database to gzip file"
+echo -e "\n$(now) Dumping snapshot database to gzip file"
 HEIGHT="$(psql -d lisk_snapshot -t -c 'select height from blocks order by height desc limit 1;' | xargs)"
 BACKUP_FULLPATH="${BACKUP_LOCATION}/${SOURCE_DB_NAME}_backup-${HEIGHT}.gz"
 pg_dump -O "$TARGET_DB_NAME" | gzip > "$BACKUP_FULLPATH"
 
 if [ "$GENERIC_COPY" == "Y" ] 2> /dev/null; then
-  echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Overwriting Generic Copy"
+  echo -e "\n$(now) Overwriting Generic Copy"
   cp -f "$BACKUP_FULLPATH" "$BACKUP_LOCATION"/blockchain.db.gz &> /dev/null
 fi
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Cleaning up"
+echo -e "\n$(now) Cleaning up"
 bash lisk.sh stop_node -c "$SNAPSHOT_CONFIG" &> /dev/null
 dropdb --if-exists "$TARGET_DB_NAME" &> /dev/null
 rm -f "$LOCK_FILE" &> /dev/null
 
-echo -e "\n$( date +'%Y-%m-%d %H:%M:%S' ) Snapshot Complete"
+echo -e "\n$(now) Snapshot Complete"
 exit 0

--- a/scripts/lisk_snapshot.sh
+++ b/scripts/lisk_snapshot.sh
@@ -75,7 +75,7 @@ parse_option() {
           exit 1
         fi ;;
 
-		r)
+      r)
         if [ "$OPTARG" -gt "0" ] 2> /dev/null; then
           SNAPSHOT_ROUND="$OPTARG"
         elif [ "$OPTARG" == "highest" ]; then


### PR DESCRIPTION
### lisk_snapshot.sh changelog

- Change value of failed snapshot in progress from 24 hours to 30 minutes.
- Added dropdb on target database before exit
- Added missing test in waiting loop for stalled/failure detection
- Added forced full vacuum to eliminate the need for lot of freespace during process.
- Added -m params to allow custom delay between vacuum. (Instead of default 5 minutes)
- Added spacing in usage menu
- Modified end of script cleanup section.
- Move stall values to minutes and defined as variables
- Added date to start of each output line. ("now" function)
- Added locks directory creation (on snapshot server only, keep client clean and will be useful for future scripts)
- Replace PID check by lock file implementation
