### PR TITLE
Correct regressions introduced by PM2 - Closes #96

### DIFF
--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -18,9 +18,9 @@ if [ "$USER" == "root" ]; then
   exit 1
 fi
 
-LISK_CONFIG="config.json"
 PM2_CONFIG="$(pwd)/etc/pm2-lisk.json"
 PM2_APP="$(grep "name" "$PM2_CONFIG" | cut -d'"' -f4)" >> /dev/null
+LISK_CONFIG="$(grep "config" "$PM2_CONFIG" | cut -d'"' -f4 | cut -d' ' -f2)" >> /dev/null
 
 LOGS_DIR="$(pwd)/logs"
 
@@ -210,6 +210,7 @@ start_lisk() {
   pm2 start "$PM2_CONFIG"  >> "$SH_LOG_FILE"
   if [ $? == 0 ]; then
     echo "√ Lisk started successfully."
+    sleep 3
     check_status
   else
     echo "X Failed to start Lisk."
@@ -290,6 +291,7 @@ parse_option() {
         if [ -f "$OPTARG" ]; then
           PM2_CONFIG="$OPTARG"
           PM2_APP="$(grep "name" "$PM2_CONFIG" | cut -d'"' -f4)"
+          LISK_CONFIG="$(grep "config" "$PM2_CONFIG" | cut -d'"' -f4 | cut -d' ' -f2)" >> /dev/null
         else
           echo "PM2-config.json not found. Please verify the file exists and try again."
           exit 1


### PR DESCRIPTION
Prior to PM2 we would specify config.json as part of startup.
This file is now specified in PM2.json. There fore we need to
repoint the LISK_CONFIG var to the value in that file since
the old way no longer works to find the DB.

On startup Lisk generates a DAPP password if there is not one
present in the file. The sleep that allowed this to work was
removed in the PM2 migration causing a regression in the
installation of the software.

This fix corrects both of these issues by re adding the sleep
and changing the way the LISK_CONFIG var is set

Closes #96 