### PR TITLE
Fixed PM2 Home path security issue

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -8,3 +8,8 @@ export PATH="$(pwd)/bin:$(pwd)/pgsql/bin:$PATH"
 # We dont care about return code here
 # shellcheck disable=SC2155
 export LD_LIBRARY_PATH="$(pwd)/pgsql/lib:$LD_LIBRARY_PATH"
+
+# Detect if lisk run under security system account to fake home dir to fix security issue with pm2 
+if ! [[ -d "/home/$USER" ]];then 
+	export HOME="$(pwd)/home"
+fi

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -3,10 +3,6 @@
 # shellcheck disable=SC2129
 
 cd "$(cd -P -- "$(dirname -- "$0")" && pwd -P)" || exit 2
-# shellcheck disable=SC1090
-. "$(pwd)/shared.sh"
-# shellcheck disable=SC1090
-. "$(pwd)/env.sh"
 
 if [ ! -f "$(pwd)/app.js" ]; then
   echo "Error: Lisk installation was not found. Exiting."
@@ -17,6 +13,11 @@ if [ "$USER" == "root" ]; then
   echo "Error: Lisk should not be run be as root. Exiting."
   exit 1
 fi
+
+# shellcheck disable=SC1090
+. "$(pwd)/shared.sh"
+# shellcheck disable=SC1090
+. "$(pwd)/env.sh"
 
 PM2_CONFIG="$(pwd)/etc/pm2-lisk.json"
 PM2_APP="$(grep "name" "$PM2_CONFIG" | cut -d'"' -f4)" >> /dev/null


### PR DESCRIPTION
Fixed home path declaration in case of lisk running under security account 
Fixed includes calls before security validation check 