### PR TITLE
Insert GPL3 header into installLisk.sh - Closes #108

### DIFF
--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#LiskHQ/Lisk-Build
+#Copyright (C) 2017  Lisk Foundation
+#
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, either version 3 of the License, or
+#(at your option) any later version.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+######################################################################
 
 # Variable Declaration
 UNAME=$(uname)-$(uname -m)

--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
-#LiskHQ/Lisk-Build
-#Copyright (C) 2017  Lisk Foundation
 #
-#This program is free software: you can redistribute it and/or modify
-#it under the terms of the GNU General Public License as published by
-#the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
-
-#This program is distributed in the hope that it will be useful,
-#but WITHOUT ANY WARRANTY; without even the implied warranty of
-#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#GNU General Public License for more details.
+# LiskHQ/lisk-build
+# Copyright (C) 2017 Lisk Foundation
 #
-#You should have received a copy of the GNU General Public License
-#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ######################################################################
 
 # Variable Declaration


### PR DESCRIPTION
In order to tag installLisk.sh as GPL3 we must insert the header
since this file is hosted standalone on the downloads repository

Closes #108