### PR TITLE
Replace MD5 with SHA256 Checksums for Binaries - Closes #113

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,10 +134,10 @@ exec_cmd "GZIP=-6 tar -czvf ../release/lisk-source.tar.gz lisk-source"
 echo "Checksumming archives..."
 echo "--------------------------------------------------------------------------"
 cd ../release || exit 2
-exec_cmd "$MD5_CMD $BUILD_NAME.tar.gz > $BUILD_NAME.tar.gz.md5"
-exec_cmd "$MD5_CMD $NOVER_BUILD_NAME.tar.gz > $NOVER_BUILD_NAME.tar.gz.md5"
-exec_cmd "$MD5_CMD lisk-node-$OS-$ARCH.tar.gz > lisk-node-$OS-$ARCH.tar.gz.md5"
-exec_cmd "$MD5_CMD lisk-source.tar.gz > lisk-source.tar.gz.md5"
+exec_cmd "$SHA_SUM $BUILD_NAME.tar.gz > $BUILD_NAME.tar.gz.SHA256"
+exec_cmd "$SHA_SUM $NOVER_BUILD_NAME.tar.gz > $NOVER_BUILD_NAME.tar.gz.SHA256"
+exec_cmd "$SHA_SUM lisk-node-$OS-$ARCH.tar.gz > lisk-node-$OS-$ARCH.tar.gz.SHA256"
+exec_cmd "$SHA_SUM lisk-source.tar.gz > lisk-source.tar.gz.SHA256"
 cd ../src || exit 2
 
 echo "Cleaning up..."

--- a/build.sh
+++ b/build.sh
@@ -134,10 +134,10 @@ exec_cmd "GZIP=-6 tar -czvf ../release/lisk-source.tar.gz lisk-source"
 echo "Checksumming archives..."
 echo "--------------------------------------------------------------------------"
 cd ../release || exit 2
-exec_cmd "$SHA_SUM $BUILD_NAME.tar.gz > $BUILD_NAME.tar.gz.SHA256"
-exec_cmd "$SHA_SUM $NOVER_BUILD_NAME.tar.gz > $NOVER_BUILD_NAME.tar.gz.SHA256"
-exec_cmd "$SHA_SUM lisk-node-$OS-$ARCH.tar.gz > lisk-node-$OS-$ARCH.tar.gz.SHA256"
-exec_cmd "$SHA_SUM lisk-source.tar.gz > lisk-source.tar.gz.SHA256"
+exec_cmd "$SHA_CMD $BUILD_NAME.tar.gz > $BUILD_NAME.tar.gz.SHA256"
+exec_cmd "$SHA_CMD $NOVER_BUILD_NAME.tar.gz > $NOVER_BUILD_NAME.tar.gz.SHA256"
+exec_cmd "$SHA_CMD lisk-node-$OS-$ARCH.tar.gz > lisk-node-$OS-$ARCH.tar.gz.SHA256"
+exec_cmd "$SHA_CMD lisk-source.tar.gz > lisk-source.tar.gz.SHA256"
 cd ../src || exit 2
 
 echo "Cleaning up..."

--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,7 @@ if [ ! -z "$1" ]; then
   ARCH="$1"
 fi
 
-VERSION="0.7.0"
+VERSION="0.8.0c"
 OS=$(uname)
 [ ! -z "$ARCH" ] || ARCH=$(uname -m)
 BUILD_NAME="lisk-$VERSION-$OS-$ARCH"
@@ -20,7 +20,7 @@ JOBS="2"
 
 LISK_DIR="$VERSION"
 LISK_FILE="$VERSION.tar.gz"
-LISK_NETWORK="main"
+LISK_NETWORK="test"
 LISK_URL="http://downloads.lisk.io/lisk/$LISK_NETWORK/$VERSION/$LISK_FILE"
 LISK_CONFIG=""
 
@@ -58,10 +58,10 @@ else
   SED_OPTS="-i"
 fi
 
-if [ "$(uname -s)" == "FreeBSD" ]; then
-  MD5_CMD="md5"
+if [ "$(uname -s)" == "Darwin" ]; then
+  MD5_CMD="shasum -a 256"
 else
-  MD5_CMD="md5sum"
+  MD5_CMD="sha256sum"
 fi
 
 if [ "$ARCH" == "armv6l" ]; then

--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,7 @@ if [ ! -z "$1" ]; then
   ARCH="$1"
 fi
 
-VERSION="0.8.0c"
+VERSION="0.8.0"
 OS=$(uname)
 [ ! -z "$ARCH" ] || ARCH=$(uname -m)
 BUILD_NAME="lisk-$VERSION-$OS-$ARCH"
@@ -20,7 +20,7 @@ JOBS="2"
 
 LISK_DIR="$VERSION"
 LISK_FILE="$VERSION.tar.gz"
-LISK_NETWORK="test"
+LISK_NETWORK="main"
 LISK_URL="http://downloads.lisk.io/lisk/$LISK_NETWORK/$VERSION/$LISK_FILE"
 LISK_CONFIG=""
 

--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -220,23 +220,23 @@ install_lisk() {
 
   curl --progress-bar -o "$LISK_VERSION" "https://downloads.lisk.io/lisk/$RELEASE/$LISK_VERSION"
 
-  curl -s "https://downloads.lisk.io/lisk/$RELEASE/$LISK_VERSION.md5" -o "$LISK_VERSION".md5
+  curl -s "https://downloads.lisk.io/lisk/$RELEASE/$LISK_VERSION.SHA256" -o "$LISK_VERSION".SHA256
 
   if [[ "$(uname)" == "Linux" ]]; then
-    md5=$(md5sum "$LISK_VERSION" | awk '{print $1}')
+    SHA256=$(SHA256sum "$LISK_VERSION" | awk '{print $1}')
   elif [[ "$(uname)" == "FreeBSD" ]]; then
-    md5=$(md5 "$LISK_VERSION" | awk '{print $1}')
+    SHA256=$(SHA256 "$LISK_VERSION" | awk '{print $1}')
   elif [[ "$(uname)" == "Darwin" ]]; then
-    md5=$(md5 "$LISK_VERSION" | awk '{print $4}')
+    SHA256=$(SHA256 "$LISK_VERSION" | awk '{print $4}')
   fi
 
-  md5_compare=$(grep "$LISK_VERSION" "$LISK_VERSION".md5 | awk '{print $1}')
+  SHA256_compare=$(grep "$LISK_VERSION" "$LISK_VERSION".SHA256 | awk '{print $1}')
 
-  if [[ "$md5" == "$md5_compare" ]]; then
+  if [[ "$SHA256" == "$SHA256_compare" ]]; then
     echo -e "\nChecksum Passed!"
   else
     echo -e "\nChecksum Failed, aborting installation"
-    rm -f "$LISK_VERSION" "$LISK_VERSION".md5
+    rm -f "$LISK_VERSION" "$LISK_VERSION".SHA256
     exit 0
   fi
 
@@ -247,7 +247,7 @@ install_lisk() {
   mv "$LISK_LOCATION/$LISK_DIR" "$LISK_INSTALL"
 
   echo -e "\nCleaning up downloaded files"
-  rm -f "$LISK_VERSION" "$LISK_VERSION".md5
+  rm -f "$LISK_VERSION" "$LISK_VERSION".SHA256
 }
 
 configure_lisk() {


### PR DESCRIPTION
Currently we use MD5 to check the integrity of the binaries. These can be falsified. This PR will replace MD5 with SHA256.

Closes #113 