### PR TITLE
Add cleanup for PM2 GOD - Closes #125

### DIFF
--- a/release/installLisk.sh
+++ b/release/installLisk.sh
@@ -247,6 +247,9 @@ backup_lisk() {
   cd "$LISK_INSTALL" || exit 2
   bash lisk.sh stop
 
+  echo -e "\nCleaning up PM2"
+  bash lisk.sh cleanup
+
   echo -e "\nBacking up existing Lisk Folder"
 
   LISK_BACKUP="$LISK_LOCATION"'/backup/lisk-'"$RELEASE"


### PR DESCRIPTION
Cleans up PM2 during Lisk upgrade to prevent orphaned process managers.