### PR TITLE
Correct redis flag detection during node shutdown - Closes #141

### DIFF
--- a/etc/redis.conf
+++ b/etc/redis.conf
@@ -9,9 +9,6 @@
 # Redis -- Isabella Dell @isabello
 port 6380
 
-# Setting redis default password @isabello
-requirepass vgeuwrKZLYwNyZXNc7vTFbjJ4vQnMGrs
-
 # Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
 #

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -242,10 +242,10 @@ stop_redis() {
 
       # Necessary to pass the right password string to redis
       if [[ "$REDIS_PASSWORD" ]]; then
-        REDIS_PASSWORD="-a $REDIS_PASSWORD"
+        REDIS_FLAG="-a"
       fi
 
-      "$REDIS_CLI" -p "$REDIS_PORT" "$REDIS_PASSWORD" shutdown
+      "$REDIS_CLI" -p "$REDIS_PORT" "$REDIS_FLAG" "$REDIS_PASSWORD" shutdown
       if [ $? == 0 ]; then
         echo "√ Redis-Server stopped successfully."
       else


### PR DESCRIPTION
This PR corrects the issue #141 . It passes the flag and the password separately resolving a literal interpretation problem.

 Closes #141