### PR TITLE
Refactor Redis to accomodate Lisk-Core Changes - Closes #148

### DIFF
--- a/etc/snapshot.json
+++ b/etc/snapshot.json
@@ -26,8 +26,7 @@
       "host": "127.0.0.1",
       "port": 6380,
       "db": 0,
-      "user": "",
-      "password": ""
+      "password": null
     },
     "api": {
         "enabled": true,

--- a/etc/snapshot.json
+++ b/etc/snapshot.json
@@ -67,6 +67,9 @@
         "releaseLimit": 5,
         "relayLimit": 5
     },
+    "transactions": {
+        "maxTxsPerQueue": 1000
+    },
     "forging": {
         "force": false,
         "secret": [],

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -42,7 +42,7 @@ REDIS_BIN="$(pwd)/bin/redis-server"
 REDIS_CLI="$(pwd)/bin/redis-cli"
 REDIS_ENABLED="$(grep "cacheEnabled" "$LISK_CONFIG" | cut -f 2 -d ':' |  sed 's: ::g' | cut -f 1 -d ',')"
 REDIS_PORT="$(grep "port" "$LISK_CONFIG" -m3 | sed -n 3p | cut -f 2 -d':' | sed 's: ::g' | cut -f 1 -d ',')"
-REDIS_PASSWORD="$(grep "password" "$LISK_CONFIG" -m2 | sed -n 2p | cut -f 2 -d ":" | cut -f 2 -d '"')"
+REDIS_PASSWORD="$(grep "password" "$LISK_CONFIG" -m2 | sed -n 2p | cut -f 2 -d ":" | cut -f 1 -d ',' | sed 's: ::g')"
 REDIS_PID="$(pwd)/redis/redis_6380.pid"
 }
 
@@ -249,11 +249,12 @@ stop_redis() {
     elif [[ -f "$REDIS_PID" ]]; then
 
       # Necessary to pass the right password string to redis
-      if [[ "$REDIS_PASSWORD" ]]; then
-        REDIS_PASSWORD="-a $REDIS_PASSWORD"
+      if [[ "$REDIS_PASSWORD" != null ]]; then
+        "$REDIS_CLI" -p "$REDIS_PORT" "-a $REDIS_PASSWORD" shutdown
+      else
+        "$REDIS_CLI" -p "$REDIS_PORT" shutdown
       fi
 
-      "$REDIS_CLI" -p "$REDIS_PORT" "$REDIS_PASSWORD" shutdown
       if [ $? == 0 ]; then
         echo "√ Redis-Server stopped successfully."
       else


### PR DESCRIPTION
In core we have removed user from the redis object and changed password to be `null`. This PR updates the logic for parsing these fields and updates snapshot.json to have the expected fields.

Closes #148