### PR TITLE
Clear specific files rpath values - Closes #153

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,7 +113,8 @@ if [ ! -d "$BUILD_NAME/node_modules" ]; then
 
   if [[ "$(uname)" == "Linux" ]]; then
     chrpath -d "$(pwd)/node_modules/sodium/deps/libsodium/test/default/.libs/"*
-    chrpath -d "$(pwd)/lib/"*
+    chrpath -d "$(pwd)/lib/libreadline.so.7.0"
+    chrpath -d "$(pwd)/lib/libhistory.so.7.0"
   fi # Change rpaths on linux
 
   cd ../ || exit 2


### PR DESCRIPTION
Libreadline and Libhistory needed their rpath values cleared. Unfortunately, chrpath chokes on one file and fails in the previous implementation.

This implementation only clears the two specific files in the folder instead of failing out on the first entry.