### PR TITLE
Compile pgcrypto in postgresql build - Closes #164

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,13 @@ if [ ! -f "$POSTGRESQL_DIR/$POSTGRESQL_OUT/bin/psql" ]; then
 
   exec_cmd "make --jobs=$JOBS"
   exec_cmd "make install"
+
+  # Compiles the pgcrypto extension
+
+  cd "$(pwd)/contrib/pgcrypto" || exit 2
+  exec_cmd "make"
+  exec_cmd "make install"
+
   cd ../ || exit 2
 fi
 


### PR DESCRIPTION
PGCrypto will be required in 1.0.0. This PR builds and installs the extension into the binaries for use by lisk.