### PR TITLE
Remove logging from oldConfig and cleanup - Closes #158

### DIFF
--- a/scripts/updateConfig.js
+++ b/scripts/updateConfig.js
@@ -4,7 +4,7 @@ var path = require('path');
 var extend = require('extend');
 
 program
-	.version('0.1.0')
+	.version('0.1.1')
 	.option('-o, --old <path>', 'Old config.json')
 	.option('-n, --new <path>', 'New config.json')
 	.parse(process.argv);
@@ -15,6 +15,8 @@ if (program.old) {
 	oldConfig = JSON.parse(fs.readFileSync(program.old, 'utf8'));
 	delete oldConfig.version;
 	delete oldConfig.minVersion;
+	delete oldConfig.consoleLogLevel;
+	delete oldConfig.fileLogLevel;
 	delete oldConfig.forging.force;
 	delete oldConfig.peers.list;
 
@@ -22,21 +24,13 @@ if (program.old) {
 		delete oldConfig.db.user;
 	}
 } else {
-	console.log('Old config.json not provided, please populate entries manually');
+	console.log('Previous config.json not found, exiting.');
 	process.exit(1);
 }
 
 if (program.new) {
 	newConfig = JSON.parse(fs.readFileSync(program.new, 'utf8'));
 	newConfig = extend(true, {}, newConfig, oldConfig);
-
-	// Migrate peers blacklist between <= 0.6.0 and >= 0.7.0
-	if (newConfig.peers && newConfig.peers.access) {
-		if (Array.isArray(newConfig.peers.blackList) && Array.isArray(newConfig.peers.access.blackList)) {
-			newConfig.peers.access.blackList = newConfig.peers.blackList;
-			delete newConfig.peers.blackList;
-		}
-	}
 
 	fs.writeFile(program.new, JSON.stringify(newConfig, null, 4), function (err) {
 		if (err) {


### PR DESCRIPTION
Remove old logging entries from config file to enforce standards.