### PR TITLE
Add support for lisky in binaries install - Closes #183

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -166,9 +166,14 @@ exec_cmd "cp -vR $NODE_DIR/$NODE_OUT/* $BUILD_NAME/"
 exec_cmd "sed $SED_OPTS \"s%$(head -1 "$NPM_CLI")%#\!.\/bin\/node%g\" $NPM_CLI"
 
 cd "$BUILD_NAME" || exit 2
+
+echo "Installing PM2 and Lisky..."
+echo "--------------------------------------------------------------------------"
 # shellcheck disable=SC1090
 . "$(pwd)/env.sh"
+
 exec_cmd "npm install -g pm2"
+exec_cmd "npm install -g --production lisky"
 cd ../ || exit 2
 
 echo "Stamping build..."

--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,7 @@ echo "--------------------------------------------------------------------------
 . "$(pwd)/env.sh"
 
 exec_cmd "npm install -g pm2"
-exec_cmd "npm install -g --production lisky"
+exec_cmd "npm install --global --production lisky"
 # Add symbolic link to lisky from root dir
 exec_cmd "ln -s ./bin/lisky lisky"
 cd ../ || exit 2

--- a/build.sh
+++ b/build.sh
@@ -174,6 +174,8 @@ echo "--------------------------------------------------------------------------
 
 exec_cmd "npm install -g pm2"
 exec_cmd "npm install -g --production lisky"
+# Add symbolic link to lisky from root dir
+exec_cmd "ln -s ./bin/lisky lisky"
 cd ../ || exit 2
 
 echo "Stamping build..."

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -319,6 +319,10 @@ check_pid() {
 	fi
 }
 
+lisky() {
+	node lisky
+}
+
 tail_logs() {
 	tail -f "$LISK_LOGS"
 }
@@ -335,6 +339,7 @@ help() {
 	echo -e "start_db                              Starts the PostgreSQL database"
 	echo -e "stop_db                               Stops the PostgreSQL database"
 	echo -e "coldstart                             Creates the PostgreSQL database and configures config.json for Lisk"
+	echo -e "lisky                                 Launches Lisky"
 	echo -e "logs                                  Displays and tails logs for Lisk"
 	echo -e "status                                Displays the status of the PID associated with Lisk"
 	echo -e "help                                  Displays this message"
@@ -427,13 +432,16 @@ case $1 in
 "logs")
 	tail_logs
 	;;
+"lisky")
+	lisky
+	;;
 "help")
 	help
 	;;
 *)
 	echo "Error: Unrecognized command."
 	echo ""
-	echo "Available commands are: start stop start_node stop_node start_db stop_db reload rebuild coldstart logs status help"
+	echo "Available commands are: start stop start_node stop_node start_db stop_db reload rebuild coldstart logs lisky status help"
 	help
 	;;
 esac

--- a/scripts/lisk.sh
+++ b/scripts/lisk.sh
@@ -320,7 +320,7 @@ check_pid() {
 }
 
 lisky() {
-	node lisky
+	node "$(pwd)/bin/lisky"
 }
 
 tail_logs() {


### PR DESCRIPTION
Adds support for lisky in binary builds. Symbolic link allows for easy execution for users with node installed on the system, or advanced users who use `env.sh`. Support for lisky directly in `lisk.sh` is also added.